### PR TITLE
feat: adding to helm external cert + api convention (MAPCO-2529)

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -7,8 +7,13 @@ metadata:
   name: {{ $releaseName }}-{{ $chartName }}-ingress
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    {{- if eq .Values.ingress.type "nginx-org" }}
     nginx.org/mergeable-ingress-type: "minion"
-    nginx.org/rewrites: 'serviceName={{ $releaseName }}-{{ $chartName }} rewrite=/'    
+    nginx.org/rewrites: 'serviceName={{ $releaseName }}-{{ $chartName }} rewrite=/'
+    {{- end }}
+    {{- if eq .Values.ingress.type "nginx-kubernetes" }}
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    {{- end }}    
     nginx.org/location-snippets: |
       if ($request_method = OPTIONS) {
         return 204;
@@ -20,10 +25,16 @@ metadata:
       add_header 'Access-Control-Allow-Headers' '*';
     {{- end }}
 spec:
+{{- if .Values.ingress.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host | quote }}
+    secretName: ingress-tls-secret
+  {{- end }}
   rules:
   - http:
       paths:
-      - path: {{ .Values.ingress.path }}
+      - path: {{ .Values.ingress.path }}{{- if eq .Values.ingress.type "nginx-kubernetes" }}(.*){{- end }}
         pathType: Prefix
         backend:
           service:

--- a/helm/templates/route.yaml
+++ b/helm/templates/route.yaml
@@ -12,12 +12,23 @@ metadata:
     haproxy.router.openshift.io/timeout: {{ .Values.route.timeout.duration }}
     {{- end }}
 spec:
+  {{- if .Values.route.host }}
+  host: {{ .Values.route.host }}
+  {{- end }}
   path:  {{ .Values.route.path | default "/" }}
   port:
     targetPort: external
   to:
     kind: Service
     name: {{ $releaseName }}-{{ $chartName }}
+  {{- if .Values.route.https }}
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+    {{- if .Values.route.useCert }}
+    certificate: {{ .Files.Get "config/cert.pem" | quote }}
+    key: {{ .Files.Get "config/key.pem" | quote }}
+    caCertificate: {{ .Files.Get "config/caCertificate.pem" | quote }}
+    {{- end }}
+  {{- end -}}
 {{- end -}}

--- a/helm/templates/tls-secrect.yaml
+++ b/helm/templates/tls-secrect.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.ingress.tls.enabled .Values.ingress.enabled (not .Values.ingress.tls.useExternal) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ingress-tls-secret
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Files.Get "config/cert.pem" | b64enc }}
+  tls.key: {{ .Files.Get "config/key.pem" | b64enc }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -109,15 +109,22 @@ resources:
 
 route:
   enabled: true
-  path: /
+  host:
+  path: /api/raster/v1
+  https: true
+  useCert: false
   timeout:
     enabled: false # defaults to 30s by openshift
     duration: 60s # supported units (us, ms, s, m, h, d)
 
 ingress:
   enabled: false
-  path: /
+  type: 'nginx-org' # supported values: 'nginx-org' | 'nginx-kubernetes
+  path: /api/raster/v1
   host: 'localhost'
+  tls: 
+      enabled: true
+      useExternal: ''
   cors:
     enabled: true
     origin: '*'


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   |✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

1. ingress + route be able use external provided certificates
2. sub path convention (/api/raster/v1)
