### PR TITLE
feat: making dynamic tile size calculation per tile format: jpeg/png (MAPCO-2758)

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -72,6 +72,10 @@
       "__name": "JPEG_TILE_ESTIMATED_SIZE_IN_BYTES",
       "__format": "number"
     },
+    "pngTileEstimatedSizeInBytes": {
+      "__name": "PNG_TILE_ESTIMATED_SIZE_IN_BYTES",
+      "__format": "number"
+    },
     "storageFactorBuffer": {
       "__name": "STORAGE_FACTOR_BUFFER",
       "__format": "number"

--- a/config/default.json
+++ b/config/default.json
@@ -46,6 +46,7 @@
   },
   "storageEstimation": {
     "jpegTileEstimatedSizeInBytes": 12500,
+    "pngTileEstimatedSizeInBytes": 12500,
     "storageFactorBuffer": 1.25,
     "validateStorageSize": true
   },

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -32,6 +32,7 @@ data:
   DOWNLOAD_SERVER_URL: {{ .Values.rasterCommon.serviceUrls.downloadServer | quote }}
   POLLING_TIMEOUT_MS: {{ .Values.env.pollingTimeoutMS | quote }}
   JPEG_TILE_ESTIMATED_SIZE_IN_BYTES: {{ .Values.env.estimatedStorageCalculation.jpegTileEstimatedSizeInBytes | quote }}
+  PNG_TILE_ESTIMATED_SIZE_IN_BYTES: {{ .Values.env.estimatedStorageCalculation.pngTileEstimatedSizeInBytes | quote }}
   STORAGE_FACTOR_BUFFER: {{ .Values.env.estimatedStorageCalculation.storageFactorBuffer | quote }}
   VALIDATE_STORAGE_SIZE: {{ .Values.env.estimatedStorageCalculation.validateStorageSize | quote }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -96,6 +96,7 @@ env:
     shouldResetTimeout: true
   estimatedStorageCalculation:
     jpegTileEstimatedSizeInBytes: 12500
+    pngTileEstimatedSizeInBytes: 12500
     storageFactorBuffer: 1.25
     validateStorageSize: true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@map-colonies/error-types": "^1.1.5",
         "@map-colonies/express-access-log-middleware": "^1.0.0",
         "@map-colonies/js-logger": "^0.0.5",
-        "@map-colonies/mc-model-types": "^13.4.3",
+        "@map-colonies/mc-model-types": "^14.0.1",
         "@map-colonies/mc-priority-queue": "^4.0.2",
         "@map-colonies/mc-utils": "^1.6.0",
         "@map-colonies/openapi-express-viewer": "^2.0.1",
@@ -2987,9 +2987,9 @@
       }
     },
     "node_modules/@map-colonies/mc-model-types": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-13.4.3.tgz",
-      "integrity": "sha512-n6V+smVO8R8T5xlkg2p1xeeNoTKdrPfpCRaXOKie4m+YxXBVijInFuvEpmz9UMrPRs3FjHFUw+qUSZWQ4Uy4kQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.1.tgz",
+      "integrity": "sha512-WX/XzEu4jZd6ZvtOW3c8REkzdJulyKkHXaR55cWESe2QXs1cdI2uIB92J0yu9OeqZmC1r94A3C/RZs8pKsGjVA==",
       "dependencies": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"
@@ -15307,9 +15307,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -18115,9 +18115,9 @@
       }
     },
     "@map-colonies/mc-model-types": {
-      "version": "13.4.3",
-      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-13.4.3.tgz",
-      "integrity": "sha512-n6V+smVO8R8T5xlkg2p1xeeNoTKdrPfpCRaXOKie4m+YxXBVijInFuvEpmz9UMrPRs3FjHFUw+qUSZWQ4Uy4kQ==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/mc-model-types/-/mc-model-types-14.0.1.tgz",
+      "integrity": "sha512-WX/XzEu4jZd6ZvtOW3c8REkzdJulyKkHXaR55cWESe2QXs1cdI2uIB92J0yu9OeqZmC1r94A3C/RZs8pKsGjVA==",
       "requires": {
         "@types/geojson": "^7946.0.7",
         "reflect-metadata": "^0.1.13"
@@ -27574,9 +27574,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@map-colonies/error-types": "^1.1.5",
     "@map-colonies/express-access-log-middleware": "^1.0.0",
     "@map-colonies/js-logger": "^0.0.5",
-    "@map-colonies/mc-model-types": "^13.4.3",
+    "@map-colonies/mc-model-types": "^14.0.1",
     "@map-colonies/mc-priority-queue": "^4.0.2",
     "@map-colonies/mc-utils": "^1.6.0",
     "@map-colonies/openapi-express-viewer": "^2.0.1",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -134,6 +134,13 @@ export interface IStorageStatusResponse {
   size: number;
 }
 
+export interface IStorageEstimation {
+  jpegTileEstimatedSizeInBytes: number;
+  pngTileEstimatedSizeInBytes: number;
+  storageFactorBuffer: number;
+  validateStorageSize: boolean;
+}
+
 export type JobResponse = IJobResponse<IJobParameters, ITaskParameters>;
 export type TaskResponse = ITaskResponse<ITaskParameters>;
 export type CreateJobBody = ICreateJobBody<IJobParameters, ITaskParameters>;

--- a/tests/mocks/config.ts
+++ b/tests/mocks/config.ts
@@ -71,6 +71,7 @@ const registerDefaultConfig = (): void => {
     pollingTimeoutMS: 2000,
     storageEstimation: {
       jpegTileEstimatedSizeInBytes: 12500,
+      pngTileEstimatedSizeInBytes: 12500,
       storageFactorBuffer: 1.25,
       validateStorageSize: true,
     },


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |

* Removing Hard-Coded option of calculate based on jpeg estimated size 

* Making dynamic cacl according layer's tiles output format

* Now should provide configuration of PNG + JPEG single tile size