### PR TITLE
feat: first commit for new cleanup managment logic (MAPCO-2877) (MAPCO-2878)

### DIFF
--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -66,7 +66,6 @@ export class JobManagerWrapper extends JobManagerClient {
       resourceId: data.cswProductId,
       version: data.version,
       type: this.tilesJobType,
-      expirationDate,
       domain: this.jobDomain,
       parameters: {
         sanitizedBbox: data.sanitizedBbox,
@@ -122,7 +121,6 @@ export class JobManagerWrapper extends JobManagerClient {
       resourceId: data.cswProductId,
       version: data.version,
       type: this.tilesJobType,
-      expirationDate,
       domain: this.jobDomain,
       parameters: jobParameters,
       internalId: data.dbId,
@@ -274,9 +272,16 @@ export class JobManagerWrapper extends JobManagerClient {
     if (job) {
       const oldExpirationDate = new Date(job.expirationDate as Date);
       if (oldExpirationDate < newExpirationDate) {
-        this.logger.info({ jobId, oldExpirationDate, newExpirationDate }, 'Will execute update for expirationDate');
+        this.logger.info({ jobId, oldExpirationDate, newExpirationDate, msg: 'update expirationDate' });
         await this.put(getOrUpdateURL, {
-          expirationDate: newExpirationDate,
+          parameters: {
+            ...job.parameters,
+            cleanupData: {
+              ...job.parameters.cleanupData,
+              cleanupExpirationTime: newExpirationDate,
+              directoryPath: job.parameters.relativeDirectoryPath,
+            },
+          },
         });
       } else {
         const msg = 'Will not update expiration date, as current expiration date is later than current expiration date';

--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -270,7 +270,7 @@ export class JobManagerWrapper extends JobManagerClient {
 
     const job = await this.get<JobResponse | JobExportResponse | undefined>(getOrUpdateURL);
     if (job) {
-      const oldExpirationDate = new Date(job.expirationDate as Date);
+      const oldExpirationDate = new Date(job.parameters.cleanupData?.cleanupExpirationTime as Date);
       if (oldExpirationDate < newExpirationDate) {
         this.logger.info({ jobId, oldExpirationDate, newExpirationDate, msg: 'update expirationDate' });
         await this.put(getOrUpdateURL, {

--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -270,7 +270,7 @@ export class JobManagerWrapper extends JobManagerClient {
 
     const job = await this.get<JobResponse | JobExportResponse | undefined>(getOrUpdateURL);
     if (job) {
-      const oldExpirationDate = new Date(job.parameters.cleanupData?.cleanupExpirationTime as Date);
+      const oldExpirationDate = new Date(job.parameters.cleanupData?.cleanupExpirationTimeUTC as Date);
       if (oldExpirationDate < newExpirationDate) {
         this.logger.info({ jobId, oldExpirationDate, newExpirationDate, msg: 'update expirationDate' });
         await this.put(getOrUpdateURL, {
@@ -278,7 +278,7 @@ export class JobManagerWrapper extends JobManagerClient {
             ...job.parameters,
             cleanupData: {
               ...job.parameters.cleanupData,
-              cleanupExpirationTime: newExpirationDate,
+              cleanupExpirationTimeUTC: newExpirationDate,
               directoryPath: job.parameters.relativeDirectoryPath,
             },
           },

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -23,7 +23,7 @@ export interface IBaseCreatePackage {
 
 export interface ICleanupData {
   directoryPath?: string;
-  cleanupExpirationTime?: Date;
+  cleanupExpirationTimeUTC?: Date;
 }
 
 /**

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -21,6 +21,11 @@ export interface IBaseCreatePackage {
   priority?: number;
 }
 
+export interface ICleanupData {
+  directoryPath?: string;
+  cleanupExpirationTime?: Date;
+}
+
 /**
  * @deprecated GetMap API - will be deprecated on future
  */
@@ -174,6 +179,7 @@ export interface IJobParameters {
   callbackParams?: ICallbackDataBase;
   fileName: string;
   gpkgEstimatedSize?: number;
+  cleanupData?: ICleanupData;
 }
 
 export interface IJobExportParameters {
@@ -185,6 +191,7 @@ export interface IJobExportParameters {
   callbackParams?: ICallbackExportResponse;
   fileNamesTemplates: ILinkDefinition;
   gpkgEstimatedSize?: number;
+  cleanupData?: ICleanupData;
 }
 
 export declare type MergerSourceType = 'S3' | 'GPKG' | 'FS';

--- a/src/createPackage/models/createPackageManager.ts
+++ b/src/createPackage/models/createPackageManager.ts
@@ -638,7 +638,6 @@ export class CreatePackageManager {
     const processingJob = (await this.jobManagerClient.findInProgressJob(dupParams)) ?? (await this.jobManagerClient.findPendingJob(dupParams));
     if (processingJob) {
       await this.updateCallbackURLs(processingJob, newCallbacks);
-      await this.jobManagerClient.validateAndUpdateExpiration(processingJob.id);
       return {
         id: processingJob.id,
         taskIds: (processingJob.tasks as unknown as IJobResponse<IJobParameters, ITaskParameters>[]).map((t) => t.id),
@@ -657,7 +656,6 @@ export class CreatePackageManager {
       (await this.jobManagerClient.findExportJob(OperationStatus.PENDING, dupParams, true));
     if (processingJob) {
       await this.updateExportCallbackURLs(processingJob, newCallbacks);
-      await this.jobManagerClient.validateAndUpdateExpiration(processingJob.id);
       return {
         id: processingJob.id,
         taskIds: (processingJob.tasks as unknown as IJobResponse<IJobExportParameters, ITaskParameters>[]).map((t) => t.id),

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -174,11 +174,7 @@ export class TasksManager {
       percentage: isSuccess ? 100 : undefined,
     };
 
-    const cleanupData: ICleanupData = {
-      directoryPath: job.parameters.relativeDirectoryPath,
-      cleanupExpirationTime: expirationDate,
-    };
-
+    const cleanupData: ICleanupData = this.generateCleanupEntity(job.parameters, expirationDate);
     this.logger.info({ jobId: job.id, cleanupData, msg: `Generated new cleanupData param for job parameters` });
 
     try {
@@ -214,10 +210,7 @@ export class TasksManager {
       status: isSuccess ? OperationStatus.COMPLETED : OperationStatus.FAILED,
     };
 
-    const cleanupData: ICleanupData = {
-      directoryPath: job.parameters.relativeDirectoryPath,
-      cleanupExpirationTime: expirationDate,
-    };
+    const cleanupData: ICleanupData = this.generateCleanupEntity(job.parameters, expirationDate);
 
     this.logger.info({ jobId: job.id, cleanupData, msg: `Generated new cleanupData param for job parameters` });
 
@@ -258,6 +251,11 @@ export class TasksManager {
     } finally {
       await this.jobManagerClient.updateJob(job.id, updateJobParams);
     }
+  }
+
+  private generateCleanupEntity(jobParam: IJobExportParameters | IJobParameters, expirationDate: Date): ICleanupData {
+    const cleanupData = { directoryPath: jobParam.relativeDirectoryPath, cleanupExpirationTime: expirationDate };
+    return cleanupData;
   }
 
   private async generateCallbackParam(job: JobExportResponse, expirationDate: Date, errorReason?: string): Promise<ICallbackDataExportBase> {

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -174,8 +174,7 @@ export class TasksManager {
       percentage: isSuccess ? 100 : undefined,
     };
 
-    const cleanupData: ICleanupData = this.generateCleanupEntity(job.parameters, expirationDate);
-    this.logger.info({ jobId: job.id, cleanupData, msg: `Generated new cleanupData param for job parameters` });
+    const cleanupData: ICleanupData = this.generateCleanupEntity(job, expirationDate);
 
     try {
       this.logger.info({ jobId: job.id, msg: `Finalize Job` });
@@ -210,9 +209,7 @@ export class TasksManager {
       status: isSuccess ? OperationStatus.COMPLETED : OperationStatus.FAILED,
     };
 
-    const cleanupData: ICleanupData = this.generateCleanupEntity(job.parameters, expirationDate);
-
-    this.logger.info({ jobId: job.id, cleanupData, msg: `Generated new cleanupData param for job parameters` });
+    const cleanupData: ICleanupData = this.generateCleanupEntity(job, expirationDate);
 
     try {
       this.logger.info({ jobId: job.id, isSuccess, msg: `Finalize Job` });
@@ -253,8 +250,9 @@ export class TasksManager {
     }
   }
 
-  private generateCleanupEntity(jobParam: IJobExportParameters | IJobParameters, expirationDate: Date): ICleanupData {
-    const cleanupData = { directoryPath: jobParam.relativeDirectoryPath, cleanupExpirationTime: expirationDate };
+  private generateCleanupEntity(job: JobResponse | JobExportResponse, expirationDate: Date): ICleanupData {
+    const cleanupData = { directoryPath: job.parameters.relativeDirectoryPath, cleanupExpirationTimeUTC: expirationDate };
+    this.logger.info({ jobId: job.id, cleanupData, msg: `Generated new cleanupData param for job parameters` });
     return cleanupData;
   }
 

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -277,6 +277,10 @@ const completedJob: IJobResponse<IJobParameters, ITaskParameters> = {
       expirationTime: new Date(),
       targetResolution: 0.0439453125,
     },
+    cleanupData: {
+      directoryPath: 'test',
+      cleanupExpirationTime: new Date(),
+    },
 
     targetResolution: 0.0439453125,
   },
@@ -692,6 +696,10 @@ const completedExportJob: IJobResponse<IJobExportParameters, ITaskParameters> = 
       requestJobId: 'afbdd5e6-25db-4567-a81f-71e0e7d30761',
       expirationTime: new Date(),
       recordCatalogId: 'b0b19b88-aecb-4e74-b694-dfa7eada8bf7',
+    },
+    cleanupData: {
+      directoryPath: 'b0b19b88-aecb-4e74-b694-dfa7eada8bf7',
+      cleanupExpirationTime: new Date(),
     },
     gpkgEstimatedSize: 187500,
     fileNamesTemplates: {

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -279,7 +279,7 @@ const completedJob: IJobResponse<IJobParameters, ITaskParameters> = {
     },
     cleanupData: {
       directoryPath: 'test',
-      cleanupExpirationTime: new Date(),
+      cleanupExpirationTimeUTC: new Date(),
     },
 
     targetResolution: 0.0439453125,
@@ -699,7 +699,7 @@ const completedExportJob: IJobResponse<IJobExportParameters, ITaskParameters> = 
     },
     cleanupData: {
       directoryPath: 'b0b19b88-aecb-4e74-b694-dfa7eada8bf7',
-      cleanupExpirationTime: new Date(),
+      cleanupExpirationTimeUTC: new Date(),
     },
     gpkgEstimatedSize: 187500,
     fileNamesTemplates: {

--- a/tests/mocks/data/mockJob.ts
+++ b/tests/mocks/data/mockJob.ts
@@ -88,7 +88,7 @@ export const mockCompletedJob: JobExportResponse = {
   reason: '',
   isCleaned: false,
   priority: 0,
-  expirationDate: new Date(),
+  expirationDate: undefined,
   internalId: '880a9316-0f10-4874-92e2-a62d587a1169',
   producerName: undefined,
   productName: 'test',

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -6,6 +6,7 @@ import { JobResponse, ICreateJobResponse as JobInProgressResponse, JobExportDupl
 import { configMock, registerDefaultConfig } from '../../mocks/config';
 import {
   completedExportJob,
+  completedJob,
   fc1,
   inProgressExportJob,
   inProgressJob,
@@ -131,14 +132,20 @@ describe('JobManagerClient', () => {
         putFun = jest.fn();
         (jobManagerClient as unknown as { put: unknown }).put = putFun.mockResolvedValue(undefined);
         const jobManager = jobManagerClient as unknown as { get: unknown };
-        jobManager.get = get.mockResolvedValue({ ...inProgressJob, expirationDate: testExpirationDate });
+        jobManager.get = get.mockResolvedValue({
+          ...completedJob,
+          parameters: {
+            ...completedJob.parameters,
+            cleanupData: { ...completedJob.parameters.cleanupData, cleanupExpirationTime: testExpirationDate },
+          },
+        });
 
-        await jobManagerClient.validateAndUpdateExpiration(inProgressJob.id);
+        await jobManagerClient.validateAndUpdateExpiration(completedJob.id);
 
         expect(get).toHaveBeenCalledTimes(1);
         expect(putFun).toHaveBeenCalledTimes(1);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const expirationParamCall: Date = putFun.mock.calls[0][1].expirationDate;
+        const expirationParamCall: Date = putFun.mock.calls[0][1].parameters.cleanupData.cleanupExpirationTime;
         expirationParamCall.setSeconds(0, 0);
         expect(JSON.stringify(expirationParamCall)).toBe(JSON.stringify(expectedNewExpirationDate));
       });
@@ -272,7 +279,7 @@ describe('JobManagerClient', () => {
         });
       });
       describe('Update Jobs', () => {
-        it('should successfully update running Export job (already in progress) expirationDate (old expirationDate lower)', async () => {
+        it('should successfully update completed Export job (Naive cache) expirationDate (old expirationDate lower)', async () => {
           const expirationDays: number = configMock.get('jobManager.expirationDays');
           const testExpirationDate = getUTCDate();
           const expectedNewExpirationDate = getUTCDate();
@@ -284,19 +291,19 @@ describe('JobManagerClient', () => {
           putFun = jest.fn();
           (jobManagerClient as unknown as { put: unknown }).put = putFun.mockResolvedValue(undefined);
           const jobManager = jobManagerClient as unknown as { get: unknown };
-          jobManager.get = get.mockResolvedValue({ ...inProgressExportJob, expirationDate: testExpirationDate });
+          jobManager.get = get.mockResolvedValue({ ...completedExportJob });
 
-          await jobManagerClient.validateAndUpdateExpiration(inProgressExportJob.id);
+          await jobManagerClient.validateAndUpdateExpiration(completedExportJob.id);
 
           expect(get).toHaveBeenCalledTimes(1);
           expect(putFun).toHaveBeenCalledTimes(1);
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          const expirationParamCall: Date = putFun.mock.calls[0][1].expirationDate;
+          const expirationParamCall: Date = putFun.mock.calls[0][1].parameters.cleanupData.cleanupExpirationTime;
           expirationParamCall.setSeconds(0, 0);
           expect(JSON.stringify(expirationParamCall)).toBe(JSON.stringify(expectedNewExpirationDate));
         });
 
-        it('should not update running Export job (already in progress) expirationDate (old expirationDate higher)', async () => {
+        it('should not update completed Export job (naive cache) expirationDate (old expirationDate higher)', async () => {
           const expirationDays: number = configMock.get('jobManager.expirationDays');
           const testExpirationDate = getUTCDate();
           const expectedNewExpirationDate = getUTCDate();
@@ -308,9 +315,15 @@ describe('JobManagerClient', () => {
           putFun = jest.fn();
           (jobManagerClient as unknown as { put: unknown }).put = putFun.mockResolvedValue(undefined);
           const jobManager = jobManagerClient as unknown as { get: unknown };
-          jobManager.get = get.mockResolvedValue({ ...inProgressExportJob, expirationDate: testExpirationDate });
+          jobManager.get = get.mockResolvedValue({
+            ...completedExportJob,
+            parameters: {
+              ...completedExportJob.parameters,
+              cleanupData: { ...completedExportJob.parameters.cleanupData, cleanupExpirationTime: testExpirationDate },
+            },
+          });
 
-          await jobManagerClient.validateAndUpdateExpiration(inProgressExportJob.id);
+          await jobManagerClient.validateAndUpdateExpiration(completedExportJob.id);
 
           expect(get).toHaveBeenCalledTimes(1);
           expect(putFun).toHaveBeenCalledTimes(0);

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -136,7 +136,7 @@ describe('JobManagerClient', () => {
           ...completedJob,
           parameters: {
             ...completedJob.parameters,
-            cleanupData: { ...completedJob.parameters.cleanupData, cleanupExpirationTime: testExpirationDate },
+            cleanupData: { ...completedJob.parameters.cleanupData, cleanupExpirationTimeUTC: testExpirationDate },
           },
         });
 
@@ -145,7 +145,7 @@ describe('JobManagerClient', () => {
         expect(get).toHaveBeenCalledTimes(1);
         expect(putFun).toHaveBeenCalledTimes(1);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-        const expirationParamCall: Date = putFun.mock.calls[0][1].parameters.cleanupData.cleanupExpirationTime;
+        const expirationParamCall: Date = putFun.mock.calls[0][1].parameters.cleanupData.cleanupExpirationTimeUTC;
         expirationParamCall.setSeconds(0, 0);
         expect(JSON.stringify(expirationParamCall)).toBe(JSON.stringify(expectedNewExpirationDate));
       });
@@ -298,7 +298,7 @@ describe('JobManagerClient', () => {
           expect(get).toHaveBeenCalledTimes(1);
           expect(putFun).toHaveBeenCalledTimes(1);
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-          const expirationParamCall: Date = putFun.mock.calls[0][1].parameters.cleanupData.cleanupExpirationTime;
+          const expirationParamCall: Date = putFun.mock.calls[0][1].parameters.cleanupData.cleanupExpirationTimeUTC;
           expirationParamCall.setSeconds(0, 0);
           expect(JSON.stringify(expirationParamCall)).toBe(JSON.stringify(expectedNewExpirationDate));
         });
@@ -319,7 +319,7 @@ describe('JobManagerClient', () => {
             ...completedExportJob,
             parameters: {
               ...completedExportJob.parameters,
-              cleanupData: { ...completedExportJob.parameters.cleanupData, cleanupExpirationTime: testExpirationDate },
+              cleanupData: { ...completedExportJob.parameters.cleanupData, cleanupExpirationTimeUTC: testExpirationDate },
             },
           });
 

--- a/tests/unit/createPackage/models/tasksModel.spec.ts
+++ b/tests/unit/createPackage/models/tasksModel.spec.ts
@@ -451,10 +451,10 @@ describe('TasksManager', () => {
           reason: undefined,
           percentage: 100,
           status: OperationStatus.COMPLETED,
-          expirationDate: expirationTime,
           parameters: {
             ...mockCompletedJob.parameters,
             callbackParams: { ...expectedCallbackParamData, roi: mockCompletedJob.parameters.roi, status: OperationStatus.COMPLETED },
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
           },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime);
@@ -495,10 +495,10 @@ describe('TasksManager', () => {
           reason: undefined,
           percentage: 100,
           status: OperationStatus.COMPLETED,
-          expirationDate: expirationTime,
           parameters: {
             ...mockCompletedJob.parameters,
             callbackParams: { ...expectedCallbackParamData, roi: mockCompletedJob.parameters.roi, status: OperationStatus.COMPLETED },
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
           },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime);
@@ -526,7 +526,10 @@ describe('TasksManager', () => {
           reason: JSON.stringify({ message: 'failed generate metadata.json' }),
           percentage: 100,
           status: OperationStatus.FAILED,
-          expirationDate: expirationTime,
+          parameters: {
+            ...mockCompletedJob.parameters,
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
+          },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime);
         await expect(action()).resolves.not.toThrow();
@@ -560,10 +563,10 @@ describe('TasksManager', () => {
           reason: 'testError',
           percentage: undefined,
           status: OperationStatus.FAILED,
-          expirationDate: expirationTime,
           parameters: {
             ...mockCompletedJob.parameters,
             callbackParams: { ...expectedCallbackParamData, roi: mockCompletedJob.parameters.roi, status: OperationStatus.FAILED },
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
           },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime, false, 'testError');

--- a/tests/unit/createPackage/models/tasksModel.spec.ts
+++ b/tests/unit/createPackage/models/tasksModel.spec.ts
@@ -454,7 +454,7 @@ describe('TasksManager', () => {
           parameters: {
             ...mockCompletedJob.parameters,
             callbackParams: { ...expectedCallbackParamData, roi: mockCompletedJob.parameters.roi, status: OperationStatus.COMPLETED },
-            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTimeUTC: expirationTime },
           },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime);
@@ -498,7 +498,7 @@ describe('TasksManager', () => {
           parameters: {
             ...mockCompletedJob.parameters,
             callbackParams: { ...expectedCallbackParamData, roi: mockCompletedJob.parameters.roi, status: OperationStatus.COMPLETED },
-            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTimeUTC: expirationTime },
           },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime);
@@ -528,7 +528,7 @@ describe('TasksManager', () => {
           status: OperationStatus.FAILED,
           parameters: {
             ...mockCompletedJob.parameters,
-            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTimeUTC: expirationTime },
           },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime);
@@ -566,7 +566,7 @@ describe('TasksManager', () => {
           parameters: {
             ...mockCompletedJob.parameters,
             callbackParams: { ...expectedCallbackParamData, roi: mockCompletedJob.parameters.roi, status: OperationStatus.FAILED },
-            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTime: expirationTime },
+            cleanupData: { directoryPath: mockCompletedJob.parameters.relativeDirectoryPath, cleanupExpirationTimeUTC: expirationTime },
           },
         };
         const action = async () => tasksManager.finalizeExportJob(mockCompletedJob, expirationTime, false, 'testError');


### PR DESCRIPTION
Generic cleanupData

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                      |
| Breaking change | ✔                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                     |

As we would like to reuse exporter-clean as generic cleanup tool for jobs on jobManager, we would like create dedicated object in params that responsible for "what" and "when" to delete