### PR TITLE
chore: updating min-max resolutions validation values

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -270,7 +270,7 @@ components:
           features:
             - type: Feature
               properties:
-                maxResolutionDeg: 0.072
+                maxResolutionDeg: 0.0439453125
               geometry:
                 type: Polygon
                 coordinates:
@@ -434,8 +434,8 @@ components:
           properties:
             maxResolutionDeg:
               type: number
-              minimum: 9.e-8
-              maximum: 0.072
+              minimum: 0.000000335276126861572
+              maximum: 0.703125
               format: double
               description: max resolution of layer in degrees/pixel
         geometry:

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -532,7 +532,7 @@ const fcTooHighResolution: FeatureCollection = {
   features: [
     {
       type: 'Feature',
-      properties: { maxResolutionDeg: 0.000000167638063430786 },
+      properties: { maxResolutionDeg: 0.000000335276126861572 },
       geometry: {
         coordinates: [
           [

--- a/tests/unit/common/utils/utils.spec.ts
+++ b/tests/unit/common/utils/utils.spec.ts
@@ -69,9 +69,9 @@ describe('Utils', () => {
 
       it('should return array of 1 IGeometry objects', () => {
         const expectedObjectBase = {
-          zoomLevel: 22,
-          targetResolutionDeg: 1.67638063430786e-7,
-          targetResolutionMeter: 0.0185,
+          zoomLevel: 21,
+          targetResolutionDeg: 0.000000335276126861572,
+          targetResolutionMeter: 0.037,
         };
         const result = utils.parseFeatureCollection(fcTooHighResolution);
         expect(result).toHaveLength(1);


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✔                                                                       |

Min Max resolution to support exporting between zooms 0-21