### PR TITLE
chore: add 'isNewTarget' task parameter (MAPCO-3254)

### DIFF
--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -79,6 +79,7 @@ export class JobManagerWrapper extends JobManagerClient {
         {
           type: this.tilesTaskType,
           parameters: {
+            isNewTarget: true,
             batches: data.batches,
             sources: data.sources,
           },
@@ -125,6 +126,7 @@ export class JobManagerWrapper extends JobManagerClient {
         {
           type: this.tilesTaskType,
           parameters: {
+            isNewTarget: true,
             batches: data.batches,
             sources: data.sources,
           },

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -239,6 +239,7 @@ export interface IMapSource {
   };
 }
 export interface ITaskParameters {
+  isNewTarget: boolean;
   batches: ITileRange[];
   sources: IMapSource[];
 }

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -307,6 +307,7 @@ const completedJob: IJobResponse<IJobParameters, ITaskParameters> = {
       type: 'rasterTilesExporter',
       description: '',
       parameters: {
+        isNewTarget: true,
         batches: [],
         sources: [],
       },
@@ -365,6 +366,7 @@ const inProgressJob: IJobResponse<IJobParameters, ITaskParameters> = {
       type: 'rasterTilesExporter',
       description: '',
       parameters: {
+        isNewTarget: true,
         batches: [],
         sources: [],
       },
@@ -793,6 +795,7 @@ const completedExportJob: IJobResponse<IJobExportParameters, ITaskParameters> = 
       type: 'rasterTilesExporter',
       description: '',
       parameters: {
+        isNewTarget: true,
         batches: [],
         sources: [],
       },
@@ -850,6 +853,7 @@ const inProgressExportJob: IJobResponse<IJobExportParameters, ITaskParameters> =
       type: 'rasterTilesExporter',
       description: '',
       parameters: {
+        isNewTarget: true,
         batches: [],
         sources: [],
       },


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                      |

send export task parameter of 'isNewTarget' in order to improve task's export time


