### PR TITLE
chore: add "targetFormat" parameter to task(MAPCO-3285)

### DIFF
--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -80,6 +80,7 @@ export class JobManagerWrapper extends JobManagerClient {
           type: this.tilesTaskType,
           parameters: {
             isNewTarget: true,
+            targetFormat: data.targetFormat,
             batches: data.batches,
             sources: data.sources,
           },
@@ -127,6 +128,7 @@ export class JobManagerWrapper extends JobManagerClient {
           type: this.tilesTaskType,
           parameters: {
             isNewTarget: true,
+            targetFormat: data.targetFormat,
             batches: data.batches,
             sources: data.sources,
           },

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,6 +1,7 @@
 import { MultiPolygon, Polygon, BBox, FeatureCollection, Geometry } from '@turf/turf';
 import { ICreateJobBody, ICreateTaskBody, IJobResponse, ITaskResponse, OperationStatus } from '@map-colonies/mc-priority-queue';
 import { IHttpRetryConfig, ITileRange } from '@map-colonies/mc-utils';
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { ArtifactType } from './enums';
 
 export interface IConfig {
@@ -68,6 +69,7 @@ export interface IWorkerInputBase {
   batches: ITileRange[];
   sources: IMapSource[];
   gpkgEstimatedSize?: number;
+  targetFormat?: TileOutputFormat;
 }
 
 /**
@@ -240,6 +242,7 @@ export interface IMapSource {
 }
 export interface ITaskParameters {
   isNewTarget: boolean;
+  targetFormat?: TileOutputFormat;
   batches: ITileRange[];
   sources: IMapSource[];
 }

--- a/src/createPackage/models/createPackageManager.ts
+++ b/src/createPackage/models/createPackageManager.ts
@@ -202,6 +202,7 @@ export class CreatePackageManager {
       priority: priority ?? DEFAULT_PRIORITY,
       callbacks: callbacks,
       gpkgEstimatedSize: estimatesGpkgSize,
+      targetFormat: layerMetadata.tileOutputFormat,
     };
     const jobCreated = await this.jobManagerClient.create(workerInput);
     return jobCreated;
@@ -364,6 +365,7 @@ export class CreatePackageManager {
       callbacks: callbacks,
       gpkgEstimatedSize: estimatesGpkgSize,
       description,
+      targetFormat: layerMetadata.tileOutputFormat,
     };
     const jobCreated = await this.jobManagerClient.createExport(workerInput);
     return jobCreated;

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { LayerMetadata, ProductType, RecordType } from '@map-colonies/mc-model-types';
+import { LayerMetadata, ProductType, RecordType, TileOutputFormat } from '@map-colonies/mc-model-types';
 import { IJobResponse, OperationStatus } from '@map-colonies/mc-priority-queue';
 import { FeatureCollection } from '@turf/helpers';
 import {
@@ -308,6 +308,7 @@ const completedJob: IJobResponse<IJobParameters, ITaskParameters> = {
       description: '',
       parameters: {
         isNewTarget: true,
+        targetFormat: TileOutputFormat.PNG,
         batches: [],
         sources: [],
       },
@@ -367,6 +368,7 @@ const inProgressJob: IJobResponse<IJobParameters, ITaskParameters> = {
       description: '',
       parameters: {
         isNewTarget: true,
+        targetFormat: TileOutputFormat.PNG,
         batches: [],
         sources: [],
       },
@@ -796,6 +798,7 @@ const completedExportJob: IJobResponse<IJobExportParameters, ITaskParameters> = 
       description: '',
       parameters: {
         isNewTarget: true,
+        targetFormat: TileOutputFormat.JPEG,
         batches: [],
         sources: [],
       },
@@ -854,6 +857,7 @@ const inProgressExportJob: IJobResponse<IJobExportParameters, ITaskParameters> =
       description: '',
       parameters: {
         isNewTarget: true,
+        targetFormat: TileOutputFormat.JPEG,
         batches: [],
         sources: [],
       },


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                     |


Further  information:
add "targetFormat" parameter to task
