### PR TITLE
chore: removed cleanupExpirationDays duplicate from default.json (MAPCO-3771)

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -37,7 +37,6 @@
       "jobManager": {
         "url": "http://job-manager-job-manager",
         "jobDomain": "RASTER",
-        "cleanupExpirationDays": 30,
         "dequeueFinalizeIntervalMs": 1000,
         "finalizeTasksAttempts": 5
       },


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✔                                                                       |


Further  information:
Removed externalClientsConfig.clientsUrls.jobManager.cleanupExpirationDays from default.json because it isn't used. Instead we just use cleanupExpirationDays.
