### PR TITLE
feat: add mixed support to task params (MAPCO-4210)

### DIFF
--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -23,6 +23,7 @@ import {
   JobResponse,
   TaskResponse,
 } from '../common/interfaces';
+import { TileFormatStrategy } from '../common/enums';
 
 @injectable()
 export class JobManagerWrapper extends JobManagerClient {
@@ -81,6 +82,7 @@ export class JobManagerWrapper extends JobManagerClient {
           parameters: {
             isNewTarget: true,
             targetFormat: data.targetFormat,
+            outputFormatStrategy: TileFormatStrategy.Mixed,
             batches: data.batches,
             sources: data.sources,
           },
@@ -129,6 +131,7 @@ export class JobManagerWrapper extends JobManagerClient {
           parameters: {
             isNewTarget: true,
             targetFormat: data.targetFormat,
+            outputFormatStrategy: TileFormatStrategy.Mixed,
             batches: data.batches,
             sources: data.sources,
           },

--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -82,7 +82,7 @@ export class JobManagerWrapper extends JobManagerClient {
           parameters: {
             isNewTarget: true,
             targetFormat: data.targetFormat,
-            outputFormatStrategy: TileFormatStrategy.Mixed,
+            outputFormatStrategy: data.outputFormatStrategy,
             batches: data.batches,
             sources: data.sources,
           },
@@ -131,7 +131,7 @@ export class JobManagerWrapper extends JobManagerClient {
           parameters: {
             isNewTarget: true,
             targetFormat: data.targetFormat,
-            outputFormatStrategy: TileFormatStrategy.Mixed,
+            outputFormatStrategy: data.outputFormatStrategy,
             batches: data.batches,
             sources: data.sources,
           },

--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -23,7 +23,6 @@ import {
   JobResponse,
   TaskResponse,
 } from '../common/interfaces';
-import { TileFormatStrategy } from '../common/enums';
 
 @injectable()
 export class JobManagerWrapper extends JobManagerClient {

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -5,10 +5,8 @@ enum ArtifactType {
 }
 
 export enum TileFormatStrategy {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Fixed = 'fixed',
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  Mixed = 'mixed',
+  FIXED = 'fixed',
+  MIXED = 'mixed',
 }
 
 export { ArtifactType };

--- a/src/common/enums.ts
+++ b/src/common/enums.ts
@@ -4,4 +4,11 @@ enum ArtifactType {
   GPKG = 'GPKG',
 }
 
+export enum TileFormatStrategy {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Fixed = 'fixed',
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  Mixed = 'mixed',
+}
+
 export { ArtifactType };

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -2,7 +2,7 @@ import { MultiPolygon, Polygon, BBox, FeatureCollection, Geometry } from '@turf/
 import { ICreateJobBody, ICreateTaskBody, IJobResponse, ITaskResponse, OperationStatus } from '@map-colonies/mc-priority-queue';
 import { IHttpRetryConfig, ITileRange } from '@map-colonies/mc-utils';
 import { TileOutputFormat } from '@map-colonies/mc-model-types';
-import { ArtifactType } from './enums';
+import { ArtifactType, TileFormatStrategy } from './enums';
 
 export interface IConfig {
   get: <T>(setting: string) => T;
@@ -70,6 +70,7 @@ export interface IWorkerInputBase {
   sources: IMapSource[];
   gpkgEstimatedSize?: number;
   targetFormat?: TileOutputFormat;
+  outputFormatStrategy?: TileFormatStrategy;
 }
 
 /**
@@ -243,6 +244,7 @@ export interface IMapSource {
 export interface ITaskParameters {
   isNewTarget: boolean;
   targetFormat?: TileOutputFormat;
+  outputFormatStrategy?: TileFormatStrategy;
   batches: ITileRange[];
   sources: IMapSource[];
 }

--- a/src/createPackage/models/createPackageManager.ts
+++ b/src/createPackage/models/createPackageManager.ts
@@ -72,6 +72,7 @@ import {
   IStorageStatusResponse,
 } from '../../common/interfaces';
 import { JobManagerWrapper } from '../../clients/jobManagerWrapper';
+import { TileFormatStrategy } from '../../common/enums';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const geojsonhint: IHinter = require('@mapbox/geojsonhint') as IHinter;
@@ -203,6 +204,7 @@ export class CreatePackageManager {
       callbacks: callbacks,
       gpkgEstimatedSize: estimatesGpkgSize,
       targetFormat: layerMetadata.tileOutputFormat,
+      outputFormatStrategy: TileFormatStrategy.Mixed,
     };
     const jobCreated = await this.jobManagerClient.create(workerInput);
     return jobCreated;
@@ -366,6 +368,7 @@ export class CreatePackageManager {
       gpkgEstimatedSize: estimatesGpkgSize,
       description,
       targetFormat: layerMetadata.tileOutputFormat,
+      outputFormatStrategy: TileFormatStrategy.Mixed,
     };
     const jobCreated = await this.jobManagerClient.createExport(workerInput);
     return jobCreated;

--- a/src/createPackage/models/createPackageManager.ts
+++ b/src/createPackage/models/createPackageManager.ts
@@ -204,7 +204,7 @@ export class CreatePackageManager {
       callbacks: callbacks,
       gpkgEstimatedSize: estimatesGpkgSize,
       targetFormat: layerMetadata.tileOutputFormat,
-      outputFormatStrategy: TileFormatStrategy.Mixed,
+      outputFormatStrategy: TileFormatStrategy.MIXED,
     };
     const jobCreated = await this.jobManagerClient.create(workerInput);
     return jobCreated;
@@ -368,7 +368,7 @@ export class CreatePackageManager {
       gpkgEstimatedSize: estimatesGpkgSize,
       description,
       targetFormat: layerMetadata.tileOutputFormat,
-      outputFormatStrategy: TileFormatStrategy.Mixed,
+      outputFormatStrategy: TileFormatStrategy.MIXED,
     };
     const jobCreated = await this.jobManagerClient.createExport(workerInput);
     return jobCreated;

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -1081,46 +1081,46 @@ const pycswRecord = {
 };
 
 const jobPayloadWithMixedForFixedStrategyCheck = {
-  "additionalIdentifiers": "1a26c1661df10eee54f9727fcdb8b71d",
-  "description": undefined,
-  "domain": "RASTER",
-  "internalId": "0c3e455f-4aeb-4258-982d-f7773469a92d",
-  "parameters": undefined,
-  "priority": 0,
-  "productName": "string",
-  "productType": "OrthophotoHistory",
-  "resourceId": "string",
-  "status": "In-Progress",
-  "tasks": [
-      {
-          "parameters": {
-              "batches": [],
-              "isNewTarget": true,
-              "outputFormatStrategy": "mixed",
-              "sources": [
-                  {
-                      "extent": {
-                          "maxX": 37.42414218385065,
-                          "maxY": 17.95036866237062,
-                          "minX": 25.120393802953117,
-                          "minY": -16.979479051947962
-                      },
-                      "path": "1a26c1661df10eee54f9727fcdb8b71d/OrthophotoHistory_string_1_0_5_2023_03_02T05_43_27_066Z.gpkg",
-                      "type": "GPKG"
-                  },
-                  {
-                      "path": "undefined/undefined",
-                      "type": "S3"
-                  }
-              ],
-              "targetFormat": undefined
+  additionalIdentifiers: '1a26c1661df10eee54f9727fcdb8b71d',
+  description: undefined,
+  domain: 'RASTER',
+  internalId: '0c3e455f-4aeb-4258-982d-f7773469a92d',
+  parameters: undefined,
+  priority: 0,
+  productName: 'string',
+  productType: 'OrthophotoHistory',
+  resourceId: 'string',
+  status: 'In-Progress',
+  tasks: [
+    {
+      parameters: {
+        batches: [],
+        isNewTarget: true,
+        outputFormatStrategy: 'mixed',
+        sources: [
+          {
+            extent: {
+              maxX: 37.42414218385065,
+              maxY: 17.95036866237062,
+              minX: 25.120393802953117,
+              minY: -16.979479051947962,
+            },
+            path: '1a26c1661df10eee54f9727fcdb8b71d/OrthophotoHistory_string_1_0_5_2023_03_02T05_43_27_066Z.gpkg',
+            type: 'GPKG',
           },
-          "type": "rasterTilesExporter"
-      }
+          {
+            path: 'undefined/undefined',
+            type: 'S3',
+          },
+        ],
+        targetFormat: undefined,
+      },
+      type: 'rasterTilesExporter',
+    },
   ],
-  "type": "rasterTilesExporter",
-  "version": "1.0"
-}
+  type: 'rasterTilesExporter',
+  version: '1.0',
+};
 
 export {
   layerFromCatalog,
@@ -1146,5 +1146,5 @@ export {
   layerMetadataRoi,
   layerMetadataSample,
   pycswRecord,
-  jobPayloadWithMixedForFixedStrategyCheck
+  jobPayloadWithMixedForFixedStrategyCheck,
 };

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -11,6 +11,7 @@ import {
   IWorkerExportInput,
   IWorkerInput,
 } from '../../src/common/interfaces';
+import { TileFormatStrategy } from '../../src/common/enums';
 
 const layerMetadata: LayerMetadata = {
   type: 'RECORD_RASTER',
@@ -267,6 +268,7 @@ const completedJob: IJobResponse<IJobParameters, ITaskParameters> = {
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.PNG,
+        outputFormatStrategy: TileFormatStrategy.Mixed,
         batches: [],
         sources: [],
       },
@@ -327,6 +329,7 @@ const inProgressJob: IJobResponse<IJobParameters, ITaskParameters> = {
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.PNG,
+        outputFormatStrategy: TileFormatStrategy.Mixed,
         batches: [],
         sources: [],
       },
@@ -757,6 +760,7 @@ const completedExportJob: IJobResponse<IJobExportParameters, ITaskParameters> = 
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.JPEG,
+        outputFormatStrategy: TileFormatStrategy.Mixed,
         batches: [],
         sources: [],
       },
@@ -816,6 +820,7 @@ const inProgressExportJob: IJobResponse<IJobExportParameters, ITaskParameters> =
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.JPEG,
+        outputFormatStrategy: TileFormatStrategy.Mixed,
         batches: [],
         sources: [],
       },

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -268,7 +268,7 @@ const completedJob: IJobResponse<IJobParameters, ITaskParameters> = {
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.PNG,
-        outputFormatStrategy: TileFormatStrategy.Mixed,
+        outputFormatStrategy: TileFormatStrategy.MIXED,
         batches: [],
         sources: [],
       },
@@ -329,7 +329,7 @@ const inProgressJob: IJobResponse<IJobParameters, ITaskParameters> = {
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.PNG,
-        outputFormatStrategy: TileFormatStrategy.Mixed,
+        outputFormatStrategy: TileFormatStrategy.MIXED,
         batches: [],
         sources: [],
       },
@@ -760,7 +760,7 @@ const completedExportJob: IJobResponse<IJobExportParameters, ITaskParameters> = 
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.JPEG,
-        outputFormatStrategy: TileFormatStrategy.Mixed,
+        outputFormatStrategy: TileFormatStrategy.MIXED,
         batches: [],
         sources: [],
       },
@@ -820,7 +820,7 @@ const inProgressExportJob: IJobResponse<IJobExportParameters, ITaskParameters> =
       parameters: {
         isNewTarget: true,
         targetFormat: TileOutputFormat.JPEG,
-        outputFormatStrategy: TileFormatStrategy.Mixed,
+        outputFormatStrategy: TileFormatStrategy.MIXED,
         batches: [],
         sources: [],
       },

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -1080,6 +1080,48 @@ const pycswRecord = {
   } as unknown as LayerMetadata,
 };
 
+const jobPayloadWithMixedForFixedStrategyCheck = {
+  "additionalIdentifiers": "1a26c1661df10eee54f9727fcdb8b71d",
+  "description": undefined,
+  "domain": "RASTER",
+  "internalId": "0c3e455f-4aeb-4258-982d-f7773469a92d",
+  "parameters": undefined,
+  "priority": 0,
+  "productName": "string",
+  "productType": "OrthophotoHistory",
+  "resourceId": "string",
+  "status": "In-Progress",
+  "tasks": [
+      {
+          "parameters": {
+              "batches": [],
+              "isNewTarget": true,
+              "outputFormatStrategy": "mixed",
+              "sources": [
+                  {
+                      "extent": {
+                          "maxX": 37.42414218385065,
+                          "maxY": 17.95036866237062,
+                          "minX": 25.120393802953117,
+                          "minY": -16.979479051947962
+                      },
+                      "path": "1a26c1661df10eee54f9727fcdb8b71d/OrthophotoHistory_string_1_0_5_2023_03_02T05_43_27_066Z.gpkg",
+                      "type": "GPKG"
+                  },
+                  {
+                      "path": "undefined/undefined",
+                      "type": "S3"
+                  }
+              ],
+              "targetFormat": undefined
+          },
+          "type": "rasterTilesExporter"
+      }
+  ],
+  "type": "rasterTilesExporter",
+  "version": "1.0"
+}
+
 export {
   layerFromCatalog,
   workerInput,
@@ -1104,4 +1146,5 @@ export {
   layerMetadataRoi,
   layerMetadataSample,
   pycswRecord,
+  jobPayloadWithMixedForFixedStrategyCheck
 };

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -207,18 +207,19 @@ describe('JobManagerClient', () => {
           workerExportInput.outputFormatStrategy = TileFormatStrategy.Fixed;
           const response = await jobManagerClient.createExport(workerExportInput);
           expect(createJob).toHaveBeenCalledTimes(1);
-          expect(createJob).toHaveBeenCalledWith(
-            {
-              ...jobPayloadWithMixedForFixedStrategyCheck, 
-              tasks: [{
-                ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0], 
-                parameters: { 
-                  ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,  
-                  outputFormatStrategy: TileFormatStrategy.Fixed
-                }
-              }],
-              parameters: expect.anything()
-            })
+          expect(createJob).toHaveBeenCalledWith({
+            ...jobPayloadWithMixedForFixedStrategyCheck,
+            tasks: [
+              {
+                ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0],
+                parameters: {
+                  ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,
+                  outputFormatStrategy: TileFormatStrategy.Fixed,
+                },
+              },
+            ],
+            parameters: expect.anything() as unknown,
+          });
           expect(response).toStrictEqual(expectedResponse);
         });
       });

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -195,61 +195,36 @@ describe('JobManagerClient', () => {
           expect(response).toStrictEqual(expectedResponse);
         });
 
-        it('should create Export job successfully with MIXED tiles strategy', async () => {
-          const inProgressJobIds = { jobId: '123', taskIds: ['123'] };
-          const expectedResponse: ICreateExportJobResponse = {
-            ...inProgressJobIds,
-            status: OperationStatus.IN_PROGRESS,
-          };
+        it.each([TileFormatStrategy.MIXED, TileFormatStrategy.FIXED])(
+          'should create Export job successfully with %p tiles strategy',
+          async (strategy: TileFormatStrategy) => {
+            const inProgressJobIds = { jobId: '123', taskIds: ['123'] };
+            const expectedResponse: ICreateExportJobResponse = {
+              ...inProgressJobIds,
+              status: OperationStatus.IN_PROGRESS,
+            };
 
-          createJob = jest.fn();
-          (jobManagerClient as unknown as { createJob: unknown }).createJob = createJob.mockResolvedValue({ id: '123', taskIds: ['123'] });
-          workerExportInput.outputFormatStrategy = TileFormatStrategy.MIXED;
-          const response = await jobManagerClient.createExport(workerExportInput);
-          expect(createJob).toHaveBeenCalledTimes(1);
-          expect(createJob).toHaveBeenCalledWith({
-            ...jobPayloadWithMixedForFixedStrategyCheck,
-            tasks: [
-              {
-                ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0],
-                parameters: {
-                  ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,
-                  outputFormatStrategy: TileFormatStrategy.MIXED,
+            createJob = jest.fn();
+            (jobManagerClient as unknown as { createJob: unknown }).createJob = createJob.mockResolvedValue({ id: '123', taskIds: ['123'] });
+            workerExportInput.outputFormatStrategy = strategy;
+            const response = await jobManagerClient.createExport(workerExportInput);
+            expect(createJob).toHaveBeenCalledTimes(1);
+            expect(createJob).toHaveBeenCalledWith({
+              ...jobPayloadWithMixedForFixedStrategyCheck,
+              tasks: [
+                {
+                  ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0],
+                  parameters: {
+                    ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,
+                    outputFormatStrategy: strategy,
+                  },
                 },
-              },
-            ],
-            parameters: expect.anything() as unknown,
-          });
-          expect(response).toStrictEqual(expectedResponse);
-        });
-
-        it('should create Export job successfully with FIXED tiles strategy', async () => {
-          const inProgressJobIds = { jobId: '123', taskIds: ['123'] };
-          const expectedResponse: ICreateExportJobResponse = {
-            ...inProgressJobIds,
-            status: OperationStatus.IN_PROGRESS,
-          };
-
-          createJob = jest.fn();
-          (jobManagerClient as unknown as { createJob: unknown }).createJob = createJob.mockResolvedValue({ id: '123', taskIds: ['123'] });
-          workerExportInput.outputFormatStrategy = TileFormatStrategy.FIXED;
-          const response = await jobManagerClient.createExport(workerExportInput);
-          expect(createJob).toHaveBeenCalledTimes(1);
-          expect(createJob).toHaveBeenCalledWith({
-            ...jobPayloadWithMixedForFixedStrategyCheck,
-            tasks: [
-              {
-                ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0],
-                parameters: {
-                  ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,
-                  outputFormatStrategy: TileFormatStrategy.FIXED,
-                },
-              },
-            ],
-            parameters: expect.anything() as unknown,
-          });
-          expect(response).toStrictEqual(expectedResponse);
-        });
+              ],
+              parameters: expect.anything() as unknown,
+            });
+            expect(response).toStrictEqual(expectedResponse);
+          }
+        );
       });
 
       describe('Get Export Jobs', () => {

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -195,7 +195,7 @@ describe('JobManagerClient', () => {
           expect(response).toStrictEqual(expectedResponse);
         });
 
-        it('should create Export job successfully with Mixed tiles strategy', async () => {
+        it('should create Export job successfully with MIXED tiles strategy', async () => {
           const inProgressJobIds = { jobId: '123', taskIds: ['123'] };
           const expectedResponse: ICreateExportJobResponse = {
             ...inProgressJobIds,
@@ -204,7 +204,7 @@ describe('JobManagerClient', () => {
 
           createJob = jest.fn();
           (jobManagerClient as unknown as { createJob: unknown }).createJob = createJob.mockResolvedValue({ id: '123', taskIds: ['123'] });
-          workerExportInput.outputFormatStrategy = TileFormatStrategy.Mixed;
+          workerExportInput.outputFormatStrategy = TileFormatStrategy.MIXED;
           const response = await jobManagerClient.createExport(workerExportInput);
           expect(createJob).toHaveBeenCalledTimes(1);
           expect(createJob).toHaveBeenCalledWith({
@@ -214,7 +214,7 @@ describe('JobManagerClient', () => {
                 ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0],
                 parameters: {
                   ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,
-                  outputFormatStrategy: TileFormatStrategy.Mixed,
+                  outputFormatStrategy: TileFormatStrategy.MIXED,
                 },
               },
             ],
@@ -223,7 +223,7 @@ describe('JobManagerClient', () => {
           expect(response).toStrictEqual(expectedResponse);
         });
 
-        it('should create Export job successfully with Fixed tiles strategy', async () => {
+        it('should create Export job successfully with FIXED tiles strategy', async () => {
           const inProgressJobIds = { jobId: '123', taskIds: ['123'] };
           const expectedResponse: ICreateExportJobResponse = {
             ...inProgressJobIds,
@@ -232,7 +232,7 @@ describe('JobManagerClient', () => {
 
           createJob = jest.fn();
           (jobManagerClient as unknown as { createJob: unknown }).createJob = createJob.mockResolvedValue({ id: '123', taskIds: ['123'] });
-          workerExportInput.outputFormatStrategy = TileFormatStrategy.Fixed;
+          workerExportInput.outputFormatStrategy = TileFormatStrategy.FIXED;
           const response = await jobManagerClient.createExport(workerExportInput);
           expect(createJob).toHaveBeenCalledTimes(1);
           expect(createJob).toHaveBeenCalledWith({
@@ -242,7 +242,7 @@ describe('JobManagerClient', () => {
                 ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0],
                 parameters: {
                   ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,
-                  outputFormatStrategy: TileFormatStrategy.Fixed,
+                  outputFormatStrategy: TileFormatStrategy.FIXED,
                 },
               },
             ],

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -195,6 +195,34 @@ describe('JobManagerClient', () => {
           expect(response).toStrictEqual(expectedResponse);
         });
 
+        it('should create Export job successfully with Mixed tiles strategy', async () => {
+          const inProgressJobIds = { jobId: '123', taskIds: ['123'] };
+          const expectedResponse: ICreateExportJobResponse = {
+            ...inProgressJobIds,
+            status: OperationStatus.IN_PROGRESS,
+          };
+
+          createJob = jest.fn();
+          (jobManagerClient as unknown as { createJob: unknown }).createJob = createJob.mockResolvedValue({ id: '123', taskIds: ['123'] });
+          workerExportInput.outputFormatStrategy = TileFormatStrategy.Mixed;
+          const response = await jobManagerClient.createExport(workerExportInput);
+          expect(createJob).toHaveBeenCalledTimes(1);
+          expect(createJob).toHaveBeenCalledWith({
+            ...jobPayloadWithMixedForFixedStrategyCheck,
+            tasks: [
+              {
+                ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0],
+                parameters: {
+                  ...jobPayloadWithMixedForFixedStrategyCheck.tasks[0].parameters,
+                  outputFormatStrategy: TileFormatStrategy.Mixed,
+                },
+              },
+            ],
+            parameters: expect.anything() as unknown,
+          });
+          expect(response).toStrictEqual(expectedResponse);
+        });
+
         it('should create Export job successfully with Fixed tiles strategy', async () => {
           const inProgressJobIds = { jobId: '123', taskIds: ['123'] };
           const expectedResponse: ICreateExportJobResponse = {


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Add task support for Mixed format in GPKG file - "outputFormatStrategy": "mixed"