### PR TITLE
fix: jobs missing params(MAPCO-6788)

### DIFF
--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -44,7 +44,19 @@ export class JobManagerWrapper extends JobManagerClient {
   public async getExportJobs(queryParams: IFindJobsRequest): Promise<JobExportResponse[] | undefined> {
     this.logger.debug({ ...queryParams }, `Getting jobs that match these parameters`);
     const jobs = await this.get<JobExportResponse[] | undefined>('/jobs', queryParams as unknown as Record<string, unknown>);
+
+    if (jobs) {
+      const jobsWithParams = await Promise.all(jobs.map(async (job) => this.getExportJobById(job.id)));
+      return jobsWithParams;
+    }
+
     return jobs;
+  }
+
+  public async getExportJobById(jobId: string): Promise<JobExportResponse> {
+    this.logger.debug({ msg: `Getting export job by id`, jobId });
+    const job = await this.get<JobExportResponse>(`/jobs/${jobId}`);
+    return job;
   }
 
   public async createExport(data: IWorkerExportInput): Promise<ICreateExportJobResponse> {

--- a/tests/unit/clients/jobManagerClient.spec.ts
+++ b/tests/unit/clients/jobManagerClient.spec.ts
@@ -109,7 +109,7 @@ describe('JobManagerClient', () => {
           get = jest.fn();
           (jobManagerClient as unknown as { get: unknown }).get = get.mockResolvedValue([inProgressExportJob]);
           const response = await jobManagerClient.getExportJobs(findJobRequest);
-          expect(get).toHaveBeenCalledTimes(1);
+          expect(get).toHaveBeenCalled();
           expect(response).toBeDefined();
         });
       });


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                      |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


Further  information:
## Description
Following the breaking changes in Job Manager v4.0.0 where job parameters are no longer included in the `/jobs` API response, this PR modifies the `getExportJobs` function to fetch job with parameters individually for each in-progress job.

## Main Changes
- Implemented parallel fetching of job parameters using `Promise.all` for optimal performance

## Impact
- **API Calls**: Increased number of API calls (one additional call per in-progress job)
- **Performance**: Minimized impact by implementing parallel fetching
