### PR TITLE
fix: rename callbackUrlArray to callbackURLs in exportManager and schemas to match the openapi spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exporter-trigger",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exporter-trigger",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "@godaddy/terminus": "^4.12.1",
@@ -19,7 +19,7 @@
         "@map-colonies/mc-priority-queue": "^8.2.1",
         "@map-colonies/mc-utils": "^3.2.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
-        "@map-colonies/raster-shared": "^1.7.1",
+        "@map-colonies/raster-shared": "^1.9.2",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/schemas": "v1.3.0",
         "@map-colonies/telemetry": "^7.0.1",
@@ -4788,9 +4788,9 @@
       "license": "ISC"
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.7.1.tgz",
-      "integrity": "sha512-Zrn2zRsQXnZgvu6Uz46/NwtU2ur3A2QMMlLzIPtZ3x7gARZQfaFVxmLjtOyaFYxr9srojNcfa4RAPssCpX169g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.2.tgz",
+      "integrity": "sha512-vzaKqkIkAHCLa/gsvGeNr3J528uqaKmwDJP35Mn1/IVBA8YvpMOXsiM48ZXGlEUVBHP3W9sqy02CAQvSKAylkQ==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@map-colonies/mc-priority-queue": "^8.2.1",
     "@map-colonies/mc-utils": "^3.2.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
-    "@map-colonies/raster-shared": "^1.7.1",
+    "@map-colonies/raster-shared": "^1.9.2",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/schemas": "v1.3.0",
     "@map-colonies/telemetry": "^7.0.1",

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -11,7 +11,6 @@ import {
   TileOutputFormat,
 } from '@map-colonies/raster-shared';
 import { BBox, Geometry } from 'geojson';
-import z from 'zod';
 
 export interface IConfig {
   get: <T>(setting: string) => T;

--- a/src/export/models/exportManager.ts
+++ b/src/export/models/exportManager.ts
@@ -49,7 +49,7 @@ export class ExportManager {
 
   @withSpanAsyncV4
   public async createExport(exportRequest: CreateExportRequest): Promise<ICreateExportJobResponse | CallbackExportResponse> {
-    const { dbId: catalogId, crs, priority, callbackUrlArray, description } = exportRequest;
+    const { dbId: catalogId, crs, priority, callbackURLs, description } = exportRequest;
     const layerMetadata = await this.validationManager.findLayer(catalogId);
 
     let roi = exportRequest.roi;
@@ -61,7 +61,7 @@ export class ExportManager {
 
     const { productId, productVersion: version, maxResolutionDeg: srcRes } = layerMetadata;
     const productType = layerMetadata.productType as RasterProductTypes;
-    const callbackUrls = callbackUrlArray?.map(
+    const callbackUrls = callbackURLs?.map(
       (url) =>
         <CallbackUrl>{
           url,

--- a/src/utils/zod/schemas.ts
+++ b/src/utils/zod/schemas.ts
@@ -6,7 +6,7 @@ export const createExportRequestSchema = z.object({
   crs: z.string().optional(),
   priority: z.number().optional(),
   roi: roiFeatureCollectionSchema.optional(),
-  callbackUrlArray: callbackUrlSchema.shape.url.array().optional(),
+  callbackURLs: callbackUrlSchema.shape.url.array().optional(),
   description: z.string().optional(),
 });
 

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -600,18 +600,18 @@ export const createExportRequestWithoutCallback: CreateExportRequest = {
 
 export const createExportRequestNoRoiWithCallback: CreateExportRequest = {
   dbId: catalogId,
-  callbackUrlArray: ['http://callback1'],
+  callbackURLs: ['http://callback1'],
 };
 
 export const createExportRequestWithRoiAndCallback: CreateExportRequest = {
   dbId: catalogId,
-  callbackUrlArray: ['http://example.getmap.com/callback', 'http://example.getmap.com/callback2'],
+  callbackURLs: ['http://example.getmap.com/callback', 'http://example.getmap.com/callback2'],
   roi: defaultRoi,
 };
 
 export const createExportRequestWithRoiAndNewCallback: CreateExportRequest = {
   dbId: catalogId,
-  callbackUrlArray: ['http://example.getmap.com/callback3'],
+  callbackURLs: ['http://example.getmap.com/callback3'],
   roi: defaultRoi,
 };
 

--- a/tests/unit/utils/zod/schemas.spec.ts
+++ b/tests/unit/utils/zod/schemas.spec.ts
@@ -51,7 +51,7 @@ describe('SchemasValidations', () => {
   });
 
   it('should throw an error if callbackURLs is not an array of strings', () => {
-    expect(() => createExportRequestSchema.parse({ ...validUserExportRequest, callbackUrlArray: [123] })).toThrow();
+    expect(() => createExportRequestSchema.parse({ ...validUserExportRequest, callbackURLs: [123] })).toThrow();
   });
 
   it('should throw an error if priority is not a number', () => {


### PR DESCRIPTION


| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |


