### PR TITLE
fix: naive-cache returns cache when zoom level changed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@map-colonies/mc-priority-queue": "^8.2.1",
         "@map-colonies/mc-utils": "^3.2.0",
         "@map-colonies/openapi-express-viewer": "^3.0.0",
-        "@map-colonies/raster-shared": "^1.9.2",
+        "@map-colonies/raster-shared": "^3.1.4",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/schemas": "v1.3.0",
         "@map-colonies/telemetry": "^7.0.1",
@@ -3262,6 +3262,19 @@
         "@map-colonies/types": "^1.3.5"
       }
     },
+    "node_modules/@map-colonies/mc-model-types/node_modules/@map-colonies/raster-shared": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.10.0.tgz",
+      "integrity": "sha512-kkqpxy86u61L21EJMUKEOKhqmTdqAZTJhlvQiVjqjyDjhG3XZB+fxDls7rDOKi4caOwLl/J5Cc2SCyG2iNlBNA==",
+      "license": "ISC",
+      "dependencies": {
+        "@map-colonies/mc-priority-queue": "^8.2.1",
+        "@map-colonies/types": "^1.4.0",
+        "geojson": "^0.5.0",
+        "standard-version": "^9.5.0",
+        "zod": "^3.24.1"
+      }
+    },
     "node_modules/@map-colonies/mc-priority-queue": {
       "version": "8.2.1",
       "license": "ISC",
@@ -4788,9 +4801,9 @@
       "license": "ISC"
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.2.tgz",
-      "integrity": "sha512-vzaKqkIkAHCLa/gsvGeNr3J528uqaKmwDJP35Mn1/IVBA8YvpMOXsiM48ZXGlEUVBHP3W9sqy02CAQvSKAylkQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-3.1.4.tgz",
+      "integrity": "sha512-RDjwcT8AJ809Q72hK+mL5fs7WCEMqiz6ypZIjiW3HFDsI2zvFReQzUA5v6iw/tJut3oCF22nwxZMplYDSy0acg==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@map-colonies/mc-priority-queue": "^8.2.1",
     "@map-colonies/mc-utils": "^3.2.0",
     "@map-colonies/openapi-express-viewer": "^3.0.0",
-    "@map-colonies/raster-shared": "^1.9.2",
+    "@map-colonies/raster-shared": "^3.1.4",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/schemas": "v1.3.0",
     "@map-colonies/telemetry": "^7.0.1",

--- a/src/clients/jobManagerWrapper.ts
+++ b/src/clients/jobManagerWrapper.ts
@@ -65,7 +65,7 @@ export class JobManagerWrapper extends JobManagerClient {
   }
 
   @withSpanAsyncV4
-  public async updateJobExpirationDate(jobId: string): Promise<void> {
+  public async updateJobExpirationDate(jobId: string): Promise<Date | undefined> {
     const newExpirationDate = getUTCDate();
     newExpirationDate.setDate(newExpirationDate.getDate() + this.expirationDays);
     const job = await this.getJob<ExportJobParameters, unknown>(jobId);
@@ -82,9 +82,11 @@ export class JobManagerWrapper extends JobManagerClient {
           },
         },
       });
+      return newExpirationDate;
     } else {
       const msg = `didn't update expiration date, as current expiration date is later than current expiration date`;
       this.logger.info({ msg, jobId, oldExpirationDate, newExpirationDate });
+      return job.parameters.cleanupDataParams?.cleanupExpirationTimeUTC;
     }
   }
 

--- a/src/clients/rasterCatalogManagerClient.ts
+++ b/src/clients/rasterCatalogManagerClient.ts
@@ -13,6 +13,7 @@ export class RasterCatalogManagerClient extends HttpClient {
     @inject(SERVICES.LOGGER) protected readonly logger: Logger,
     @inject(SERVICES.TRACER) public readonly tracer: Tracer
   ) {
+    const x = config.get<string>('externalClientsConfig.clientsUrls.rasterCatalogManager.url');
     super(
       logger,
       config.get<string>('externalClientsConfig.clientsUrls.rasterCatalogManager.url'),

--- a/src/clients/rasterCatalogManagerClient.ts
+++ b/src/clients/rasterCatalogManagerClient.ts
@@ -13,7 +13,6 @@ export class RasterCatalogManagerClient extends HttpClient {
     @inject(SERVICES.LOGGER) protected readonly logger: Logger,
     @inject(SERVICES.TRACER) public readonly tracer: Tracer
   ) {
-    const x = config.get<string>('externalClientsConfig.clientsUrls.rasterCatalogManager.url');
     super(
       logger,
       config.get<string>('externalClientsConfig.clientsUrls.rasterCatalogManager.url'),

--- a/src/export/models/validationManager.ts
+++ b/src/export/models/validationManager.ts
@@ -137,10 +137,11 @@ export class ValidationManager {
     const exportJobs = await this.jobManagerClient.findExportJobs(OperationStatus.COMPLETED, dupParams);
     const duplicateJob = this.findDuplicatedExportJob(exportJobs, dupParams);
     if (duplicateJob) {
-      await this.jobManagerClient.updateJobExpirationDate(duplicateJob.id);
+      const expirationDate = await this.jobManagerClient.updateJobExpirationDate(duplicateJob.id);
       return {
         ...duplicateJob.parameters.callbackParams,
         status: OperationStatus.COMPLETED,
+        expirationTime: expirationDate,
       } as CallbackExportResponse;
     }
   }

--- a/src/export/models/validationManager.ts
+++ b/src/export/models/validationManager.ts
@@ -25,7 +25,7 @@ import {
   JobExportDuplicationParams,
   JobExportResponse,
 } from '../../common/interfaces';
-import { checkRoiFeatureCollectionResemblance, sanitizeBbox } from '../../utils/geometry';
+import { checkRoiFeatureCollectionSimilarity, sanitizeBbox } from '../../utils/geometry';
 
 @injectable()
 export class ValidationManager {
@@ -153,7 +153,7 @@ export class ValidationManager {
           job.internalId === jobParams.catalogId &&
           job.version === jobParams.version &&
           job.parameters.exportInputParams.crs === jobParams.crs &&
-          checkRoiFeatureCollectionResemblance(job.parameters.exportInputParams.roi, jobParams.roi)
+          checkRoiFeatureCollectionSimilarity(job.parameters.exportInputParams.roi, jobParams.roi, { config: this.config })
       );
       return duplicateJob;
     }

--- a/src/export/models/validationManager.ts
+++ b/src/export/models/validationManager.ts
@@ -25,7 +25,7 @@ import {
   JobExportDuplicationParams,
   JobExportResponse,
 } from '../../common/interfaces';
-import { checkFeaturesResemblance, sanitizeBbox } from '../../utils/geometry';
+import { checkRoiFeatureCollectionResemblance, sanitizeBbox } from '../../utils/geometry';
 
 @injectable()
 export class ValidationManager {
@@ -153,7 +153,7 @@ export class ValidationManager {
           job.internalId === jobParams.catalogId &&
           job.version === jobParams.version &&
           job.parameters.exportInputParams.crs === jobParams.crs &&
-          checkFeaturesResemblance(job.parameters.exportInputParams.roi, jobParams.roi)
+          checkRoiFeatureCollectionResemblance(job.parameters.exportInputParams.roi, jobParams.roi)
       );
       return duplicateJob;
     }

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -4,53 +4,101 @@ import { container } from 'tsyringe';
 import config from 'config';
 import { area, buffer, feature, featureCollection, intersect } from '@turf/turf';
 import PolygonBbox from '@turf/bbox';
-import { BBox, Geometry, MultiPolygon, Polygon } from 'geojson';
+import { BBox, Feature, MultiPolygon, Polygon } from 'geojson';
 import booleanContains from '@turf/boolean-contains';
-import { featureCollectionBooleanEqual, snapBBoxToTileGrid } from '@map-colonies/mc-utils';
-import { RoiFeatureCollection } from '@map-colonies/raster-shared';
-import { SERVICES } from '../common/constants';
+import { snapBBoxToTileGrid } from '@map-colonies/mc-utils';
+import { RoiFeatureCollection, RoiProperties } from '@map-colonies/raster-shared';
+import { SERVICES } from '@src/common/constants';
 
 const roiBufferMeter = config.get<number>('roiBufferMeter');
 const minContainedPercentage = config.get<number>('minContainedPercentage');
 
-const isSinglePolygonFeature = (fc: RoiFeatureCollection): boolean => {
-  return fc.features.length === 1 && fc.features[0].geometry.type === 'Polygon';
+const areRoiPropertiesEqual = (props1: RoiProperties, props2: RoiProperties): boolean => {
+  return props1.maxResolutionDeg === props2.maxResolutionDeg && props1.minResolutionDeg === props2.minResolutionDeg;
 };
 
-export const checkFeaturesResemblance = (jobRoi: RoiFeatureCollection, exportRoi: RoiFeatureCollection): boolean => {
-  const logger = container.resolve<Logger>(SERVICES.LOGGER);
-  // Check if both feature collections contain only a single polygon feature
-  if (!isSinglePolygonFeature(jobRoi) || !isSinglePolygonFeature(exportRoi)) {
-    logger.debug({ msg: 'One of the featureCollections is not a single polygon. Checking feature collection equality' });
-    return featureCollectionBooleanEqual(jobRoi, exportRoi);
+const areGeometriesSimilar = (feature1: Feature, feature2: Feature, options: { minContainedPercentage: number; bufferMeter: number }): boolean => {
+  // Calculate areas first
+  const area1 = area(feature1);
+  const area2 = area(feature2);
+
+  // Check direct containment
+  const feature1ContainsFeature2 = booleanContains(feature1, feature2);
+  const feature2ContainsFeature1 = booleanContains(feature2, feature1);
+
+  if (feature1ContainsFeature2 || feature2ContainsFeature1) {
+    // Even with containment, check if areas are within threshold
+    const areaRatio = Math.min(area1, area2) / Math.max(area1, area2);
+    const thresholdRatio = options.minContainedPercentage / 100;
+
+    // If the area ratio is below threshold, they're too different in size
+    if (areaRatio < thresholdRatio) {
+      return false;
+    }
+    return true;
   }
 
-  logger.debug({ msg: 'Both job featureCollection and exportRequest featureCollection are single polygon features' });
+  // Create buffered features
+  const bufferedFeature1 = buffer(feature1, options.bufferMeter, { units: 'meters' });
+  const bufferedFeature2 = buffer(feature2, options.bufferMeter, { units: 'meters' });
 
-  // Create a buffered feature around jobRoi's single polygon
-  const bufferedFeature = buffer(jobRoi.features[0], roiBufferMeter, { units: 'meters' });
-  const isContained =
-    booleanContains(bufferedFeature as unknown as Geometry, exportRoi.features[0]) || booleanContains(jobRoi.features[0], exportRoi.features[0]);
+  if (bufferedFeature1 === undefined || bufferedFeature2 === undefined) {
+    return false;
+  }
+  // Check if buffered feature1 contains feature2 or vice versa
+  return booleanContains(bufferedFeature1, feature2) || booleanContains(bufferedFeature2, feature1);
+};
 
-  // If exportRoi is not contained, return false immediately
-  if (!isContained) {
-    logger.info({ msg: 'Export ROI is not contained within buffered job ROI' });
+export const checkRoiFeatureCollectionResemblance = (fc1: RoiFeatureCollection, fc2: RoiFeatureCollection): boolean => {
+  const logger: Logger = container.resolve(SERVICES.LOGGER);
+  // If feature counts differ, they're not similar
+  if (fc1.features.length !== fc2.features.length) {
+    logger.debug({ msg: 'Feature counts differ, not similar', fc1Count: fc1.features.length, fc2Count: fc2.features.length });
     return false;
   }
 
-  // Calculate areas and check containment percentage
-  const exportArea = area(exportRoi.features[0]);
-  const jobArea = area(jobRoi.features[0]);
-  const containedPercentage = (exportArea / jobArea) * 100;
+  // Track which features have found a match
+  const fc1Matched = new Array<boolean>(fc1.features.length).fill(false);
+  const fc2Matched = new Array<boolean>(fc2.features.length).fill(false);
 
-  const isSufficientlyContained = containedPercentage >= minContainedPercentage;
-  logger.info({
-    msg: isSufficientlyContained
-      ? `Export ROI is contained within buffered job ROI with sufficient area percentage. ContainedPercentage is: ${containedPercentage}`
-      : `Export ROI does not meet minimum contained percentage within buffered job ROI. ContainedPercentage is: ${containedPercentage}, minContainedPercentage is: ${minContainedPercentage}`,
-  });
+  for (let i = 0; i < fc1.features.length; i++) {
+    const feature1 = fc1.features[i];
 
-  return isSufficientlyContained;
+    for (let j = 0; j < fc2.features.length; j++) {
+      // Skip already matched features in fc2
+      if (fc2Matched[j]) {
+        continue;
+      }
+
+      const feature2 = fc2.features[j];
+
+      // Check if properties are exactly the same
+      const propsEqual = areRoiPropertiesEqual(feature1.properties, feature2.properties);
+      logger.debug({ msg: 'Checking properties', propsEqual, feature1Properties: feature1.properties, feature2Properties: feature2.properties });
+      if (!propsEqual) {
+        continue;
+      }
+
+      // Check geometric resemblance
+      const geometriesSimilar = areGeometriesSimilar(feature1, feature2, { minContainedPercentage, bufferMeter: roiBufferMeter });
+      logger.debug({
+        msg: 'Checking geometries',
+        geometriesSimilar,
+        feature1GeometryType: feature1.geometry,
+        feature2GeometryType: feature2.geometry,
+      });
+      if (geometriesSimilar) {
+        fc1Matched[i] = true;
+        fc2Matched[j] = true;
+        break;
+      }
+    }
+  }
+
+  // Return true only if all features in both collections found a match
+  const allMatched = fc1Matched.every((matched) => matched) && fc2Matched.every((matched) => matched);
+  logger.debug({ msg: 'All features matched?', allMatched });
+  return allMatched;
 };
 
 export const sanitizeBbox = ({

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -91,12 +91,14 @@ export const checkRoiFeatureCollectionSimilarity = (fc1: RoiFeatureCollection, f
         break;
       }
     }
+    if (!fc1Matched[i]) {
+      logger.debug({ msg: 'At least one feature in fc1 has no match, featureCollection has no similarity' });
+      return false;
+    }
   }
 
-  // Return true only if all features in both collections found a match
-  const allMatched = fc1Matched.every((matched) => matched) && fc2Matched.every((matched) => matched);
-  logger.debug({ msg: 'All features matched?', allMatched });
-  return allMatched;
+  logger.debug({ msg: 'All features matched successfully, featureCollection has similarity' });
+  return true;
 };
 
 export const sanitizeBbox = ({

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -849,7 +849,7 @@ export const duplicateJobResponseWithParams = {
         packageName: 'test.gpkg',
       },
       packageRelativePath: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
-      jobTrackerServiceURL: 'https://raster-core-dev-job-tracker-route-raster-dev.apps.j1lk3njp.eastus.aroapp.io',
+      jobTrackerServiceURL: 'http://job-tracker',
       outputFormatStrategy: 'mixed',
       relativeDirectoryPath: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
       polygonPartsEntityName: 'naive_cache_check_v2_orthophoto',

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -1,8 +1,17 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import { RecordType } from '@map-colonies/mc-model-types';
 import { BBox, Polygon } from 'geojson';
-import { IFindJobsRequest, OperationStatus } from '@map-colonies/mc-priority-queue';
-import { RasterProductTypes, RoiFeatureCollection, TileFormatStrategy, TileOutputFormat, Transparency } from '@map-colonies/raster-shared';
+import { IFindJobsRequest, IJobResponse, OperationStatus } from '@map-colonies/mc-priority-queue';
+import {
+  CallbackExportResponse,
+  ExportArtifactType,
+  ExportJobParameters,
+  RasterProductTypes,
+  RoiFeatureCollection,
+  TileFormatStrategy,
+  TileOutputFormat,
+  Transparency,
+} from '@map-colonies/raster-shared';
 import { CreateExportRequest } from '@src/utils/zod/schemas';
 import {
   CreateExportJobBody,
@@ -11,8 +20,13 @@ import {
   IGeometryRecord,
   IJobStatusResponse,
   JobExportDuplicationParams,
+  LayerInfo,
 } from '../../src/common/interfaces';
 import { inProgressJobsResponse } from './processingRequest';
+
+type DateToString<T> = {
+  [K in keyof T]: T[K] extends Date ? string : T[K] extends Date | undefined ? string | undefined : T[K];
+};
 
 const catalogId = '8b867544-2dab-43a1-be6e-f23ec83c19b4';
 const crs = 'EPSG:4326';
@@ -662,16 +676,15 @@ export const createExportResponse: ICreateExportJobResponse = {
   status: OperationStatus.PENDING,
 };
 
-export const layerMetadataResponse = {
+export const layerMetadataResponse: LayerInfo = {
   metadata: {
-    type: 'RECORD_RASTER',
+    type: RecordType.RECORD_RASTER,
     description: 'string',
     producerName: 'string',
     productSubType: 'string',
     srsName: 'WGS84GEO',
     scale: 100000000,
     productBoundingBox: '-180.000000000000000,-89.999999973571548,179.999999973571533,89.999999973571548',
-    productStatus: 'UNPUBLISHED',
     classification: '6',
     id: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
     srs: '4326',
@@ -679,15 +692,15 @@ export const layerMetadataResponse = {
     maxResolutionDeg: 0.02197265625,
     minResolutionDeg: 0.02197265625,
     rms: 0,
-    creationDateUTC: '2025-05-19T08:39:37.486Z',
-    ingestionDate: '2025-05-19T08:39:37.486Z',
+    creationDateUTC: new Date('2025-05-19T08:39:37.486Z'),
+    ingestionDate: new Date('2025-05-19T08:39:37.486Z'),
     minHorizontalAccuracyCE90: 10,
     maxHorizontalAccuracyCE90: 10,
     region: ['string'],
     sensors: ['string'],
-    imagingTimeBeginUTC: '2024-01-28T13:47:43.427Z',
-    imagingTimeEndUTC: '2024-01-28T13:47:43.427Z',
-    updateDateUTC: '2025-05-19T05:39:37.486Z',
+    imagingTimeBeginUTC: new Date('2024-01-28T13:47:43.427Z'),
+    imagingTimeEndUTC: new Date('2024-01-28T13:47:43.427Z'),
+    updateDateUTC: new Date('2025-05-19T05:39:37.486Z'),
     maxResolutionMeter: 8000,
     minResolutionMeter: 8000,
     displayPath: 'dd0b2205-a79c-421d-8e06-d12d52118689',
@@ -696,7 +709,7 @@ export const layerMetadataResponse = {
     tileOutputFormat: 'PNG',
     productName: '2Parts',
     productId: 'Naive_Cache_Check_V2',
-    productType: 'Orthophoto',
+    productType: RasterProductTypes.ORTHOPHOTO,
     footprint: {
       type: 'Polygon',
       coordinates: [
@@ -711,6 +724,7 @@ export const layerMetadataResponse = {
       bbox: [-180, -89.99999997357155, 179.99999997357153, 89.99999997357155],
     },
   },
+  links: [],
 };
 
 export const roiRequest: CreateExportRequest = {
@@ -753,23 +767,24 @@ export const duplicationParams: IFindJobsRequest = {
   status: OperationStatus.COMPLETED,
 };
 
-export const duplicateJobsResponseWithoutParams = [
+export const duplicateJobsResponseWithoutParams: IJobResponse<unknown, unknown>[] = [
   {
     id: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
     resourceId: 'Naive_Cache_Check_V2',
     version: '1.0',
     type: 'Export',
+    parameters: {},
     description: 'Max zoom:1',
-    status: 'Completed',
+    status: OperationStatus.COMPLETED,
     percentage: 100,
     reason: 'Job completed successfully',
     domain: 'RASTER',
     isCleaned: false,
     priority: 0,
-    expirationDate: null,
+    expirationDate: undefined,
     internalId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
-    producerName: null,
-    productName: null,
+    producerName: undefined,
+    productName: undefined,
     productType: 'Orthophoto',
     additionalIdentifiers: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
     taskCount: 3,
@@ -784,13 +799,8 @@ export const duplicateJobsResponseWithoutParams = [
   },
 ];
 
-export const duplicateJobResponseWithParams = {
-  id: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
-  resourceId: 'Naive_Cache_Check_V2',
-  version: '1.0',
-  type: 'Export',
-  description: 'Max zoom:1',
-  internalId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
+export const duplicateJobResponseWithParams: IJobResponse<ExportJobParameters, unknown> = {
+  ...duplicateJobsResponseWithoutParams[0],
   parameters: {
     callbackParams: {
       roi: {
@@ -821,25 +831,25 @@ export const duplicateJobResponseWithParams = {
         dataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
         metadataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
       },
-      status: 'Completed',
+      status: OperationStatus.COMPLETED,
       fileSize: 102400,
       artifacts: [
         {
           url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
           name: 'test.gpkg',
           size: 102400,
-          type: 'GPKG',
+          type: ExportArtifactType.GPKG,
           sha256: '8fca0427fcc4f57cadb3799ad44d621333716c3515ccf7d15208dae0aba6adb0',
         },
         {
           url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
           name: 'test.json',
           size: 1834,
-          type: 'METADATA',
+          type: ExportArtifactType.METADATA,
         },
       ],
       description: 'The export process completed successfully.',
-      expirationTime: '2025-06-02T10:13:46.000Z',
+      expirationTime: new Date('2025-06-18T10:15:50.000Z'),
       recordCatalogId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
     },
     additionalParams: {
@@ -856,7 +866,7 @@ export const duplicateJobResponseWithParams = {
     },
     cleanupDataParams: {
       directoryPath: '/outputs/gpkgs/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
-      cleanupExpirationTimeUTC: '2025-06-18T10:15:50.000Z',
+      cleanupExpirationTimeUTC: new Date('2025-06-18T10:15:50.000Z'),
     },
     exportInputParams: {
       crs: 'EPSG:4326',
@@ -890,29 +900,9 @@ export const duplicateJobResponseWithParams = {
       ],
     },
   },
-  status: 'Completed',
-  percentage: 100,
-  reason: 'Job completed successfully',
-  domain: 'RASTER',
-  isCleaned: false,
-  priority: 0,
-  expirationDate: null,
-  producerName: null,
-  productName: null,
-  productType: 'Orthophoto',
-  additionalIdentifiers: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
-  taskCount: 3,
-  completedTasks: 3,
-  failedTasks: 0,
-  expiredTasks: 0,
-  pendingTasks: 0,
-  inProgressTasks: 0,
-  abortedTasks: 0,
-  created: '2025-05-19T10:13:41.801Z',
-  updated: '2025-05-19T10:15:51.403Z',
 };
 
-export const expectedResponse = {
+export const expectedResponse: DateToString<CallbackExportResponse> = {
   roi: {
     type: 'FeatureCollection',
     features: [
@@ -941,29 +931,40 @@ export const expectedResponse = {
     dataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
     metadataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
   },
-  status: 'Completed',
+  status: OperationStatus.COMPLETED,
   fileSize: 102400,
   artifacts: [
     {
       url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
       name: 'test.gpkg',
       size: 102400,
-      type: 'GPKG',
+      type: ExportArtifactType.GPKG,
       sha256: '8fca0427fcc4f57cadb3799ad44d621333716c3515ccf7d15208dae0aba6adb0',
     },
     {
       url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
       name: 'test.json',
       size: 1834,
-      type: 'METADATA',
+      type: ExportArtifactType.METADATA,
     },
   ],
   description: 'The export process completed successfully.',
-  expirationTime: '2025-06-02T10:13:46.000Z',
+  expirationTime: '2025-06-18T10:15:50.000Z',
   recordCatalogId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
 };
 
-export const createExportDuplicateResponseTestCases = [
+export interface Test {
+  description: string;
+  request: CreateExportRequest;
+  findLayerParams: { id: string };
+  layerMetadataResponse: LayerInfo[];
+  duplicationParams: IFindJobsRequest;
+  duplicateJobsResponseWithoutParams: IJobResponse<unknown, unknown>[];
+  duplicateJobResponseWithParams: IJobResponse<ExportJobParameters, unknown>;
+  expected: DateToString<CallbackExportResponse>;
+}
+
+export const createExportDuplicateResponseTestCases: Test[] = [
   {
     description: 'Should return existing completed job when ROI exactly matches',
     request: roiRequest,

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -818,24 +818,22 @@ export const duplicateJobResponseWithParams = {
       },
       jobId: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
       links: {
-        dataURI:
-          'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
-        metadataURI:
-          'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+        dataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
+        metadataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
       },
       status: 'Completed',
       fileSize: 102400,
       artifacts: [
         {
-          url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
-          name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+          url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
+          name: 'test.gpkg',
           size: 102400,
           type: 'GPKG',
           sha256: '8fca0427fcc4f57cadb3799ad44d621333716c3515ccf7d15208dae0aba6adb0',
         },
         {
-          url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
-          name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+          url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
+          name: 'test.json',
           size: 1834,
           type: 'METADATA',
         },
@@ -848,9 +846,9 @@ export const duplicateJobResponseWithParams = {
       targetFormat: 'PNG',
       gpkgEstimatedSize: 25000,
       fileNamesTemplates: {
-        packageName: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+        packageName: 'test.gpkg',
       },
-      packageRelativePath: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+      packageRelativePath: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
       jobTrackerServiceURL: 'https://raster-core-dev-job-tracker-route-raster-dev.apps.j1lk3njp.eastus.aroapp.io',
       outputFormatStrategy: 'mixed',
       relativeDirectoryPath: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
@@ -940,24 +938,22 @@ export const expectedResponse = {
   },
   jobId: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
   links: {
-    dataURI:
-      'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
-    metadataURI:
-      'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+    dataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
+    metadataURI: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
   },
   status: 'Completed',
   fileSize: 102400,
   artifacts: [
     {
-      url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
-      name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+      url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.gpkg',
+      name: 'test.gpkg',
       size: 102400,
       type: 'GPKG',
       sha256: '8fca0427fcc4f57cadb3799ad44d621333716c3515ccf7d15208dae0aba6adb0',
     },
     {
-      url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
-      name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+      url: 'http://download-server//downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/test.json',
+      name: 'test.json',
       size: 1834,
       type: 'METADATA',
     },

--- a/tests/mocks/data.ts
+++ b/tests/mocks/data.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import { RecordType } from '@map-colonies/mc-model-types';
 import { BBox, Polygon } from 'geojson';
-import { OperationStatus } from '@map-colonies/mc-priority-queue';
+import { IFindJobsRequest, OperationStatus } from '@map-colonies/mc-priority-queue';
 import { RasterProductTypes, RoiFeatureCollection, TileFormatStrategy, TileOutputFormat, Transparency } from '@map-colonies/raster-shared';
 import { CreateExportRequest } from '@src/utils/zod/schemas';
 import {
@@ -661,3 +661,357 @@ export const createExportResponse: ICreateExportJobResponse = {
   jobId: 'ef1a76e2-3a4b-49e6-90ee-e97c402dd3d8',
   status: OperationStatus.PENDING,
 };
+
+export const layerMetadataResponse = {
+  metadata: {
+    type: 'RECORD_RASTER',
+    description: 'string',
+    producerName: 'string',
+    productSubType: 'string',
+    srsName: 'WGS84GEO',
+    scale: 100000000,
+    productBoundingBox: '-180.000000000000000,-89.999999973571548,179.999999973571533,89.999999973571548',
+    productStatus: 'UNPUBLISHED',
+    classification: '6',
+    id: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
+    srs: '4326',
+    productVersion: '1.0',
+    maxResolutionDeg: 0.02197265625,
+    minResolutionDeg: 0.02197265625,
+    rms: 0,
+    creationDateUTC: '2025-05-19T08:39:37.486Z',
+    ingestionDate: '2025-05-19T08:39:37.486Z',
+    minHorizontalAccuracyCE90: 10,
+    maxHorizontalAccuracyCE90: 10,
+    region: ['string'],
+    sensors: ['string'],
+    imagingTimeBeginUTC: '2024-01-28T13:47:43.427Z',
+    imagingTimeEndUTC: '2024-01-28T13:47:43.427Z',
+    updateDateUTC: '2025-05-19T05:39:37.486Z',
+    maxResolutionMeter: 8000,
+    minResolutionMeter: 8000,
+    displayPath: 'dd0b2205-a79c-421d-8e06-d12d52118689',
+    transparency: 'TRANSPARENT',
+    tileMimeFormat: 'image/png',
+    tileOutputFormat: 'PNG',
+    productName: '2Parts',
+    productId: 'Naive_Cache_Check_V2',
+    productType: 'Orthophoto',
+    footprint: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-180, 89.99999970523892],
+          [179.99999997357153, 89.99999997357155],
+          [179.99999997357153, -89.99999997357155],
+          [-179.99999997357153, -89.99999997357155],
+          [-180, 89.99999970523892],
+        ],
+      ],
+      bbox: [-180, -89.99999997357155, 179.99999997357153, 89.99999997357155],
+    },
+  },
+};
+
+export const roiRequest: CreateExportRequest = {
+  dbId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
+  roi: {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {
+          maxResolutionDeg: 0.087890625,
+          minResolutionDeg: 0.703125,
+        },
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [34.479280463428466, 31.472217896295774],
+              [34.480316474833614, 31.470300615520685],
+              [34.482525329337875, 31.47145098869808],
+              [34.479280463428466, 31.472217896295774],
+            ],
+          ],
+        },
+      },
+    ],
+  },
+  callbackURLs: ['https://webhook-test.com'],
+  crs: 'EPSG:4326',
+  priority: 0,
+  description: '',
+};
+
+export const duplicationParams: IFindJobsRequest = {
+  resourceId: 'Naive_Cache_Check_V2',
+  version: '1.0',
+  isCleaned: false,
+  type: 'Export',
+  shouldReturnTasks: false,
+  status: OperationStatus.COMPLETED,
+};
+
+export const duplicateJobsResponseWithoutParams = [
+  {
+    id: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
+    resourceId: 'Naive_Cache_Check_V2',
+    version: '1.0',
+    type: 'Export',
+    description: 'Max zoom:1',
+    status: 'Completed',
+    percentage: 100,
+    reason: 'Job completed successfully',
+    domain: 'RASTER',
+    isCleaned: false,
+    priority: 0,
+    expirationDate: null,
+    internalId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
+    producerName: null,
+    productName: null,
+    productType: 'Orthophoto',
+    additionalIdentifiers: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
+    taskCount: 3,
+    completedTasks: 3,
+    failedTasks: 0,
+    expiredTasks: 0,
+    pendingTasks: 0,
+    inProgressTasks: 0,
+    abortedTasks: 0,
+    created: '2025-05-19T10:13:41.801Z',
+    updated: '2025-05-19T10:15:51.403Z',
+  },
+];
+
+export const duplicateJobResponseWithParams = {
+  id: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
+  resourceId: 'Naive_Cache_Check_V2',
+  version: '1.0',
+  type: 'Export',
+  description: 'Max zoom:1',
+  internalId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
+  parameters: {
+    callbackParams: {
+      roi: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [34.479280463428466, 31.472217896295774],
+                  [34.480316474833614, 31.470300615520685],
+                  [34.482525329337875, 31.47145098869808],
+                  [34.479280463428466, 31.472217896295774],
+                ],
+              ],
+            },
+            properties: {
+              maxResolutionDeg: 0.087890625,
+              minResolutionDeg: 0.703125,
+            },
+          },
+        ],
+      },
+      jobId: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
+      links: {
+        dataURI:
+          'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+        metadataURI:
+          'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+      },
+      status: 'Completed',
+      fileSize: 102400,
+      artifacts: [
+        {
+          url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+          name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+          size: 102400,
+          type: 'GPKG',
+          sha256: '8fca0427fcc4f57cadb3799ad44d621333716c3515ccf7d15208dae0aba6adb0',
+        },
+        {
+          url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+          name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+          size: 1834,
+          type: 'METADATA',
+        },
+      ],
+      description: 'The export process completed successfully.',
+      expirationTime: '2025-06-02T10:13:46.000Z',
+      recordCatalogId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
+    },
+    additionalParams: {
+      targetFormat: 'PNG',
+      gpkgEstimatedSize: 25000,
+      fileNamesTemplates: {
+        packageName: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+      },
+      packageRelativePath: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+      jobTrackerServiceURL: 'https://raster-core-dev-job-tracker-route-raster-dev.apps.j1lk3njp.eastus.aroapp.io',
+      outputFormatStrategy: 'mixed',
+      relativeDirectoryPath: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
+      polygonPartsEntityName: 'naive_cache_check_v2_orthophoto',
+    },
+    cleanupDataParams: {
+      directoryPath: '/outputs/gpkgs/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
+      cleanupExpirationTimeUTC: '2025-06-18T10:15:50.000Z',
+    },
+    exportInputParams: {
+      crs: 'EPSG:4326',
+      roi: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  [34.479280463428466, 31.472217896295774],
+                  [34.480316474833614, 31.470300615520685],
+                  [34.482525329337875, 31.47145098869808],
+                  [34.479280463428466, 31.472217896295774],
+                ],
+              ],
+            },
+            properties: {
+              maxResolutionDeg: 0.087890625,
+              minResolutionDeg: 0.703125,
+            },
+          },
+        ],
+      },
+      callbackUrls: [
+        {
+          url: 'https://webhook-test.com/7e3bb99c19bea30ac50fcf479802d569',
+        },
+      ],
+    },
+  },
+  status: 'Completed',
+  percentage: 100,
+  reason: 'Job completed successfully',
+  domain: 'RASTER',
+  isCleaned: false,
+  priority: 0,
+  expirationDate: null,
+  producerName: null,
+  productName: null,
+  productType: 'Orthophoto',
+  additionalIdentifiers: '6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd',
+  taskCount: 3,
+  completedTasks: 3,
+  failedTasks: 0,
+  expiredTasks: 0,
+  pendingTasks: 0,
+  inProgressTasks: 0,
+  abortedTasks: 0,
+  created: '2025-05-19T10:13:41.801Z',
+  updated: '2025-05-19T10:15:51.403Z',
+};
+
+export const expectedResponse = {
+  roi: {
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        geometry: {
+          type: 'Polygon',
+          coordinates: [
+            [
+              [34.479280463428466, 31.472217896295774],
+              [34.480316474833614, 31.470300615520685],
+              [34.482525329337875, 31.47145098869808],
+              [34.479280463428466, 31.472217896295774],
+            ],
+          ],
+        },
+        properties: {
+          maxResolutionDeg: 0.087890625,
+          minResolutionDeg: 0.703125,
+        },
+      },
+    ],
+  },
+  jobId: '4bebe2f8-5bb2-489a-8341-b80e0f704d40',
+  links: {
+    dataURI:
+      'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+    metadataURI:
+      'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+  },
+  status: 'Completed',
+  fileSize: 102400,
+  artifacts: [
+    {
+      url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+      name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.gpkg',
+      size: 102400,
+      type: 'GPKG',
+      sha256: '8fca0427fcc4f57cadb3799ad44d621333716c3515ccf7d15208dae0aba6adb0',
+    },
+    {
+      url: 'https://download-dev.mapcolonies.net/api/raster/v1/downloads/6f2a4f2c-72d0-4a52-a9ff-b4c7b833d6fd/Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+      name: 'Orthophoto_Naive_Cache_Check_V2_1_0_1_2025_05_19T10_13_41_589Z.json',
+      size: 1834,
+      type: 'METADATA',
+    },
+  ],
+  description: 'The export process completed successfully.',
+  expirationTime: '2025-06-02T10:13:46.000Z',
+  recordCatalogId: '7494fdc8-5898-4a85-babe-27f6f4a937b7',
+};
+
+export const createExportDuplicateResponseTestCases = [
+  {
+    description: 'Should return existing completed job when ROI exactly matches',
+    request: roiRequest,
+    findLayerParams: { id: layerMetadataResponse.metadata.id },
+    layerMetadataResponse: [layerMetadataResponse],
+    duplicationParams: duplicationParams,
+    duplicateJobsResponseWithoutParams,
+    duplicateJobResponseWithParams,
+    expected: expectedResponse,
+  },
+  {
+    description: 'Should return existing completed job when ROI coordinates are similar but within buffer threshold',
+    request: {
+      ...roiRequest,
+      roi: {
+        type: 'FeatureCollection',
+        features: [
+          {
+            type: 'Feature',
+            properties: {
+              maxResolutionDeg: 0.087890625,
+              minResolutionDeg: 0.703125,
+            },
+            geometry: {
+              type: 'Polygon',
+              coordinates: [
+                [
+                  // Slightly modified coordinates (about 1m difference)
+                  [34.4792805, 31.472218],
+                  [34.4803165, 31.4703007],
+                  [34.4825254, 31.4714511],
+                  [34.4792805, 31.472218],
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    },
+    findLayerParams: { id: layerMetadataResponse.metadata.id },
+    layerMetadataResponse: [layerMetadataResponse],
+    duplicationParams: duplicationParams,
+    duplicateJobsResponseWithoutParams,
+    duplicateJobResponseWithParams,
+    expected: expectedResponse,
+  },
+];

--- a/tests/unit/export/models/validationManager.spec.ts
+++ b/tests/unit/export/models/validationManager.spec.ts
@@ -217,7 +217,9 @@ describe('ValidationManager', () => {
         .reply(200, completedJobWithChangedExpiration)
         .persist();
       nock(jobManagerURL).put(`/jobs/${completedExportJobsResponse[0].id}`, JSON.stringify(updateExpirationParams)).reply(200);
+
       const expirationDateSpy = jest.spyOn(jobManagerWrapper, 'updateJobExpirationDate');
+      completedJobCallback.expirationTime = newExpirationDate as unknown as string;
 
       const result = await validationManager.checkForExportDuplicate(productId, version, catalogId, roi, crs);
 

--- a/tests/unit/export/models/validationManager.spec.ts
+++ b/tests/unit/export/models/validationManager.spec.ts
@@ -206,6 +206,10 @@ describe('ValidationManager', () => {
           },
         },
       };
+
+      const expirationDateSpy = jest.spyOn(jobManagerWrapper, 'updateJobExpirationDate');
+      const completedJobCallbackWithUpdatedExpiration = { ...completedJobCallback, expirationTime: newExpirationDate as unknown as string };
+
       completedJobWithChangedExpiration.parameters.cleanupDataParams.cleanupExpirationTimeUTC = '2025-02-01T12:28:50.000Z';
       nock(jobManagerURL)
         .get('/jobs')
@@ -218,12 +222,9 @@ describe('ValidationManager', () => {
         .persist();
       nock(jobManagerURL).put(`/jobs/${completedExportJobsResponse[0].id}`, JSON.stringify(updateExpirationParams)).reply(200);
 
-      const expirationDateSpy = jest.spyOn(jobManagerWrapper, 'updateJobExpirationDate');
-      completedJobCallback.expirationTime = newExpirationDate as unknown as string;
-
       const result = await validationManager.checkForExportDuplicate(productId, version, catalogId, roi, crs);
 
-      expect(result).toEqual(completedJobCallback);
+      expect(result).toEqual(completedJobCallbackWithUpdatedExpiration);
       expect(expirationDateSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/unit/utils/geometry.spec.ts
+++ b/tests/unit/utils/geometry.spec.ts
@@ -39,30 +39,24 @@ describe('Geometry Utils', () => {
   });
 
   describe('checkRoiFeatureCollectionSimilarity', () => {
-    function createPolygonFeature(id: string, coords: number[][], properties: RoiProperties): Feature<Polygon, RoiProperties> {
-      return {
-        type: 'Feature',
-        id,
-        properties,
-        geometry: {
-          type: 'Polygon',
-          coordinates: [coords],
-        },
-      };
-    }
     const props1 = { maxResolutionDeg: 0.1, minResolutionDeg: 0.01 };
     const props2 = { maxResolutionDeg: 0.2, minResolutionDeg: 0.02 };
 
     it('should return true when features are identical', () => {
-      const square = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', square, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2', square, props1)]);
+      const squarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
+      const fc1 = turf.featureCollection([turf.feature(squarePolygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(squarePolygon, props1, { id: 'f2' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -71,16 +65,21 @@ describe('Geometry Utils', () => {
 
     // Different feature count
     it('should return false when collections have different numbers of features', () => {
-      const square = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
+      const squarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', square, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2a', square, props1), createPolygonFeature('f2b', square, props1)]);
+      const fc1 = turf.featureCollection([turf.feature(squarePolygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(squarePolygon, props1, { id: 'f2a' }), turf.feature(squarePolygon, props1, { id: 'f2b' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -99,16 +98,21 @@ describe('Geometry Utils', () => {
 
     // Different properties
     it('should return false when features have different properties', () => {
-      const square = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
+      const squarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', square, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2', square, props2)]);
+      const fc1 = turf.featureCollection([turf.feature(squarePolygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(squarePolygon, props2, { id: 'f2' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -118,24 +122,35 @@ describe('Geometry Utils', () => {
     // Containment with area ratio within threshold
     it('should return true when one feature contains another and area ratio is within threshold', () => {
       // Square: 100 sq units
-      const outerSquare = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
-      // Inner square: 96 sq units (96% of outer) - above 90% threshold
-      const innerSquare = [
-        [0.2, 0.2],
-        [0.2, 9.8],
-        [9.8, 9.8],
-        [9.8, 0.2],
-        [0.2, 0.2],
-      ];
+      const outerSquarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', outerSquare, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2', innerSquare, props1)]);
+      // Inner square: 96 sq units (96% of outer) - above 90% threshold
+      const innerSquarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0.2, 0.2],
+            [0.2, 9.8],
+            [9.8, 9.8],
+            [9.8, 0.2],
+            [0.2, 0.2],
+          ],
+        ],
+      };
+
+      const fc1 = turf.featureCollection([turf.feature(outerSquarePolygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(innerSquarePolygon, props1, { id: 'f2' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -145,24 +160,35 @@ describe('Geometry Utils', () => {
     // Containment with area ratio below threshold
     it('should return false when one feature contains another but area ratio is below threshold', () => {
       // Square: 100 sq units
-      const outerSquare = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
-      // Inner square: 64 sq units (64% of outer) - below 90% threshold
-      const innerSquare = [
-        [2, 2],
-        [2, 8],
-        [8, 8],
-        [8, 2],
-        [2, 2],
-      ];
+      const outerSquarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', outerSquare, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2', innerSquare, props1)]);
+      // Inner square: 64 sq units (64% of outer) - below 90% threshold
+      const innerSquarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [2, 2],
+            [2, 8],
+            [8, 8],
+            [8, 2],
+            [2, 2],
+          ],
+        ],
+      };
+
+      const fc1 = turf.featureCollection([turf.feature(outerSquarePolygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(innerSquarePolygon, props1, { id: 'f2' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -172,23 +198,34 @@ describe('Geometry Utils', () => {
     // Buffer doesn't create containment
     it("should return false when buffer doesn't create containment", () => {
       // Two squares that are 10 meters apart - beyond the 5 meter buffer
-      const square1 = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
-      const square2 = [
-        [20, 0],
-        [20, 10],
-        [30, 10],
-        [30, 0],
-        [20, 0],
-      ];
+      const square1Polygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', square1, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2', square2, props1)]);
+      const square2Polygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [20, 0],
+            [20, 10],
+            [30, 10],
+            [30, 0],
+            [20, 0],
+          ],
+        ],
+      };
+
+      const fc1 = turf.featureCollection([turf.feature(square1Polygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(square2Polygon, props1, { id: 'f2' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -198,39 +235,68 @@ describe('Geometry Utils', () => {
     // Multiple features - all match
     it('should return true when all features in collections find matches', () => {
       // First collection has two squares
-      const square1a = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
-      const square1b = [
-        [20, 0],
-        [20, 10],
-        [30, 10],
-        [30, 0],
-        [20, 0],
-      ];
+      const square1aPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
+
+      const square1bPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [20, 0],
+            [20, 10],
+            [30, 10],
+            [30, 0],
+            [20, 0],
+          ],
+        ],
+      };
 
       // Second collection has matching squares (slightly smaller but within threshold)
-      const square2a = [
-        [0.5, 0.5],
-        [0.5, 9.5],
-        [9.5, 9.5],
-        [9.5, 0.5],
-        [0.5, 0.5],
-      ];
-      const square2b = [
-        [20.5, 0.5],
-        [20.5, 9.5],
-        [29.5, 9.5],
-        [29.5, 0.5],
-        [20.5, 0.5],
-      ];
+      const square2aPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0.5, 0.5],
+            [0.5, 9.5],
+            [9.5, 9.5],
+            [9.5, 0.5],
+            [0.5, 0.5],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1a', square1a, props1), createPolygonFeature('f1b', square1b, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2a', square2a, props1), createPolygonFeature('f2b', square2b, props1)]);
+      const square2bPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [20.5, 0.5],
+            [20.5, 9.5],
+            [29.5, 9.5],
+            [29.5, 0.5],
+            [20.5, 0.5],
+          ],
+        ],
+      };
+
+      const fc1 = turf.featureCollection([
+        turf.feature(square1aPolygon, props1, { id: 'f1a' }),
+        turf.feature(square1bPolygon, props1, { id: 'f1b' }),
+      ]);
+
+      const fc2 = turf.featureCollection([
+        turf.feature(square2aPolygon, props1, { id: 'f2a' }),
+        turf.feature(square2bPolygon, props1, { id: 'f2b' }),
+      ]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -240,40 +306,68 @@ describe('Geometry Utils', () => {
     // Multiple features - some don't match
     it("should return false when some features don't find matches", () => {
       // First collection has two squares
-      const square1a = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
-      const square1b = [
-        [20, 0],
-        [20, 10],
-        [30, 10],
-        [30, 0],
-        [20, 0],
-      ];
+      const square1aPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
+
+      const square1bPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [20, 0],
+            [20, 10],
+            [30, 10],
+            [30, 0],
+            [20, 0],
+          ],
+        ],
+      };
 
       // Second collection has one matching square and one non-matching
-      const square2a = [
-        [0.5, 0.5],
-        [0.5, 9.5],
-        [9.5, 9.5],
-        [9.5, 0.5],
-        [0.5, 0.5],
-      ]; // Matches square1a
-      const square2b = [
-        [40, 0],
-        [40, 10],
-        [50, 10],
-        [50, 0],
-        [40, 0],
-      ]; // Far from any square in fc1
+      const square2aPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0.5, 0.5],
+            [0.5, 9.5],
+            [9.5, 9.5],
+            [9.5, 0.5],
+            [0.5, 0.5],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1a', square1a, props1), createPolygonFeature('f1b', square1b, props1)]);
+      const square2bPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [40, 0],
+            [40, 10],
+            [50, 10],
+            [50, 0],
+            [40, 0],
+          ],
+        ],
+      };
 
-      const fc2 = turf.featureCollection([createPolygonFeature('f2a', square2a, props1), createPolygonFeature('f2b', square2b, props1)]);
+      const fc1 = turf.featureCollection([
+        turf.feature(square1aPolygon, props1, { id: 'f1a' }),
+        turf.feature(square1bPolygon, props1, { id: 'f1b' }),
+      ]);
+
+      const fc2 = turf.featureCollection([
+        turf.feature(square2aPolygon, props1, { id: 'f2a' }),
+        turf.feature(square2bPolygon, props1, { id: 'f2b' }),
+      ]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -283,42 +377,68 @@ describe('Geometry Utils', () => {
     // Multiple features - different order
     it('should match features correctly regardless of order', () => {
       // First collection has two squares
-      const square1a = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
-      const square1b = [
-        [20, 0],
-        [20, 10],
-        [30, 10],
-        [30, 0],
-        [20, 0],
-      ];
+      const square1aPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
+
+      const square1bPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [20, 0],
+            [20, 10],
+            [30, 10],
+            [30, 0],
+            [20, 0],
+          ],
+        ],
+      };
 
       // Second collection has matching squares but in reverse order
-      const square2a = [
-        [0.5, 0.5],
-        [0.5, 9.5],
-        [9.5, 9.5],
-        [9.5, 0.5],
-        [0.5, 0.5],
-      ]; // Matches square1a
-      const square2b = [
-        [20.5, 0.5],
-        [20.5, 9.5],
-        [29.5, 9.5],
-        [29.5, 0.5],
-        [20.5, 0.5],
-      ]; // Matches square1b
+      const square2aPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0.5, 0.5],
+            [0.5, 9.5],
+            [9.5, 9.5],
+            [9.5, 0.5],
+            [0.5, 0.5],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1a', square1a, props1), createPolygonFeature('f1b', square1b, props1)]);
+      const square2bPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [20.5, 0.5],
+            [20.5, 9.5],
+            [29.5, 9.5],
+            [29.5, 0.5],
+            [20.5, 0.5],
+          ],
+        ],
+      };
+
+      const fc1 = turf.featureCollection([
+        turf.feature(square1aPolygon, props1, { id: 'f1a' }),
+        turf.feature(square1bPolygon, props1, { id: 'f1b' }),
+      ]);
+
       const fc2 = turf.featureCollection([
         // Order reversed compared to fc1
-        createPolygonFeature('f2b', square2b, props1),
-        createPolygonFeature('f2a', square2a, props1),
+        turf.feature(square2bPolygon, props1, { id: 'f2b' }),
+        turf.feature(square2aPolygon, props1, { id: 'f2a' }),
       ]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
@@ -329,25 +449,36 @@ describe('Geometry Utils', () => {
     // Ambiguous matching
     it('should handle ambiguous matching correctly', () => {
       // First collection has two identical squares at the same location
-      const square1 = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
+      const square1Polygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
       // Second collection has two identical squares at the same location
-      const square2 = [
-        [0.5, 0.5],
-        [0.5, 9.5],
-        [9.5, 9.5],
-        [9.5, 0.5],
-        [0.5, 0.5],
-      ];
+      const square2Polygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0.5, 0.5],
+            [0.5, 9.5],
+            [9.5, 9.5],
+            [9.5, 0.5],
+            [0.5, 0.5],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1a', square1, props1), createPolygonFeature('f1b', square1, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2a', square2, props1), createPolygonFeature('f2b', square2, props1)]);
+      const fc1 = turf.featureCollection([turf.feature(square1Polygon, props1, { id: 'f1a' }), turf.feature(square1Polygon, props1, { id: 'f1b' })]);
+
+      const fc2 = turf.featureCollection([turf.feature(square2Polygon, props1, { id: 'f2a' }), turf.feature(square2Polygon, props1, { id: 'f2b' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -357,13 +488,18 @@ describe('Geometry Utils', () => {
     // Exactly at threshold boundary
     it('should handle area ratio exactly at threshold boundary', () => {
       // Square: 100 sq units
-      const outerSquare = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
+      const outerSquarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
       // Inner square with exactly 90% area of outer square - exactly at the threshold
       // For a square, side length = sqrt(area)
@@ -371,16 +507,21 @@ describe('Geometry Utils', () => {
       const sideLength = Math.sqrt(90);
       const offset = (10 - sideLength) / 2; // To center the smaller square
 
-      const innerSquare = [
-        [offset, offset],
-        [offset, offset + sideLength],
-        [offset + sideLength, offset + sideLength],
-        [offset + sideLength, offset],
-        [offset, offset],
-      ];
+      const innerSquarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [offset, offset],
+            [offset, offset + sideLength],
+            [offset + sideLength, offset + sideLength],
+            [offset + sideLength, offset],
+            [offset, offset],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', outerSquare, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2', innerSquare, props1)]);
+      const fc1 = turf.featureCollection([turf.feature(outerSquarePolygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(innerSquarePolygon, props1, { id: 'f2' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 
@@ -390,25 +531,35 @@ describe('Geometry Utils', () => {
     // Invalid geometry handling
     it('should handle invalid geometries gracefully', () => {
       // Create valid geometry
-      const validSquare = [
-        [0, 0],
-        [0, 10],
-        [10, 10],
-        [10, 0],
-        [0, 0],
-      ];
+      const validSquarePolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [0, 10],
+            [10, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
       // Create invalid geometry (self-intersecting polygon)
-      const invalidPolygon = [
-        [0, 0],
-        [10, 10],
-        [0, 10],
-        [10, 0],
-        [0, 0],
-      ];
+      const invalidPolygon: Polygon = {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [0, 0],
+            [10, 10],
+            [0, 10],
+            [10, 0],
+            [0, 0],
+          ],
+        ],
+      };
 
-      const fc1 = turf.featureCollection([createPolygonFeature('f1', validSquare, props1)]);
-      const fc2 = turf.featureCollection([createPolygonFeature('f2', invalidPolygon, props1)]);
+      const fc1 = turf.featureCollection([turf.feature(validSquarePolygon, props1, { id: 'f1' })]);
+      const fc2 = turf.featureCollection([turf.feature(invalidPolygon, props1, { id: 'f2' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });
 

--- a/tests/unit/utils/geometry.spec.ts
+++ b/tests/unit/utils/geometry.spec.ts
@@ -1,17 +1,11 @@
 import { container } from 'tsyringe';
+import { Feature, MultiPolygon, Polygon } from 'geojson';
 import jsLogger from '@map-colonies/js-logger';
+import { RoiFeatureCollection, RoiProperties } from '@map-colonies/raster-shared';
 import * as turf from '@turf/turf';
 import { registerDefaultConfig } from '../../mocks/config';
-import {
-  multiplePolygonsFeatureCollection,
-  jobRoiFeature,
-  containedExportRoi,
-  notContainedExportRoi,
-  sanitizeBboxMock,
-  sanitizeBboxRequestMock,
-  notIntersectedPolygon,
-} from '../../mocks/geometryMocks';
-import { checkFeaturesResemblance, sanitizeBbox } from '../../../src/utils/geometry';
+import { sanitizeBboxMock, sanitizeBboxRequestMock, notIntersectedPolygon } from '../../mocks/geometryMocks';
+import { checkRoiFeatureCollectionResemblance, sanitizeBbox } from '../../../src/utils/geometry';
 import { SERVICES } from '../../../src/common/constants';
 
 describe('Geometry Utils', () => {
@@ -22,32 +16,6 @@ describe('Geometry Utils', () => {
   });
   afterEach(() => {
     jest.restoreAllMocks();
-  });
-
-  describe('checkFeaturesResemblance', () => {
-    it('should return true when the featureCollection are strictly equal and not single polygons', () => {
-      const jobRoi = multiplePolygonsFeatureCollection;
-      const exportRoi = multiplePolygonsFeatureCollection;
-      const response = checkFeaturesResemblance(jobRoi, exportRoi);
-
-      expect(response).toBe(true);
-    });
-
-    it('should return true when the jobRoi and exportRoi are single polygons and export is contained', () => {
-      const jobRoi = jobRoiFeature;
-      const exportRoi = containedExportRoi;
-      const response = checkFeaturesResemblance(jobRoi, exportRoi);
-
-      expect(response).toBe(true);
-    });
-
-    it('should return false when the exportRoi is not contained in jobRoi', () => {
-      const jobRoi = jobRoiFeature;
-      const exportRoi = notContainedExportRoi;
-      const response = checkFeaturesResemblance(jobRoi, exportRoi);
-
-      expect(response).toBe(false);
-    });
   });
 
   describe('sanitizedBbox', () => {
@@ -67,6 +35,373 @@ describe('Geometry Utils', () => {
       });
       const action = () => sanitizeBbox({ ...sanitizeBboxRequestMock, polygon: notIntersectedPolygon });
       expect(action).toThrow(Error);
+    });
+  });
+
+  describe('checkRoiFeatureCollectionResemblance', () => {
+    function createFeatureCollection(features: Feature<Polygon | MultiPolygon, RoiProperties>[]): RoiFeatureCollection {
+      return {
+        type: 'FeatureCollection',
+        features: features,
+      };
+    }
+
+    function createPolygonFeature(id: string, coords: number[][], properties: RoiProperties): Feature<Polygon, RoiProperties> {
+      return {
+        type: 'Feature',
+        id,
+        properties,
+        geometry: {
+          type: 'Polygon',
+          coordinates: [coords],
+        },
+      };
+    }
+
+    const props1 = { maxResolutionDeg: 0.1, minResolutionDeg: 0.01 };
+    const props2 = { maxResolutionDeg: 0.2, minResolutionDeg: 0.02 };
+
+    // Different feature count
+    it('should return false when collections have different numbers of features', () => {
+      const square = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      const fc1 = createFeatureCollection([createPolygonFeature('f1', square, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2a', square, props1), createPolygonFeature('f2b', square, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(false);
+    });
+
+    // Empty feature collections
+    it('should return true when both collections are empty', () => {
+      const fc1 = createFeatureCollection([]);
+      const fc2 = createFeatureCollection([]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(true);
+    });
+
+    // Different properties
+    it('should return false when features have different properties', () => {
+      const square = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      const fc1 = createFeatureCollection([createPolygonFeature('f1', square, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2', square, props2)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(false);
+    });
+
+    // Containment with area ratio within threshold
+    it('should return true when one feature contains another and area ratio is within threshold', () => {
+      // Square: 100 sq units
+      const outerSquare = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      // Inner square: 96 sq units (96% of outer) - above 90% threshold
+      const innerSquare = [
+        [0.2, 0.2],
+        [0.2, 9.8],
+        [9.8, 9.8],
+        [9.8, 0.2],
+        [0.2, 0.2],
+      ];
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1', outerSquare, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2', innerSquare, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(true);
+    });
+
+    // Containment with area ratio below threshold
+    it('should return false when one feature contains another but area ratio is below threshold', () => {
+      // Square: 100 sq units
+      const outerSquare = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      // Inner square: 64 sq units (64% of outer) - below 90% threshold
+      const innerSquare = [
+        [2, 2],
+        [2, 8],
+        [8, 8],
+        [8, 2],
+        [2, 2],
+      ];
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1', outerSquare, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2', innerSquare, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(false);
+    });
+
+    // Buffer doesn't create containment
+    it("should return false when buffer doesn't create containment", () => {
+      // Two squares that are 10 meters apart - beyond the 5 meter buffer
+      const square1 = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      const square2 = [
+        [20, 0],
+        [20, 10],
+        [30, 10],
+        [30, 0],
+        [20, 0],
+      ];
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1', square1, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2', square2, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(false);
+    });
+
+    // Multiple features - all match
+    it('should return true when all features in collections find matches', () => {
+      // First collection has two squares
+      const square1a = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      const square1b = [
+        [20, 0],
+        [20, 10],
+        [30, 10],
+        [30, 0],
+        [20, 0],
+      ];
+
+      // Second collection has matching squares (slightly smaller but within threshold)
+      const square2a = [
+        [0.5, 0.5],
+        [0.5, 9.5],
+        [9.5, 9.5],
+        [9.5, 0.5],
+        [0.5, 0.5],
+      ];
+      const square2b = [
+        [20.5, 0.5],
+        [20.5, 9.5],
+        [29.5, 9.5],
+        [29.5, 0.5],
+        [20.5, 0.5],
+      ];
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1a', square1a, props1), createPolygonFeature('f1b', square1b, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2a', square2a, props1), createPolygonFeature('f2b', square2b, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(true);
+    });
+
+    // Multiple features - some don't match
+    it("should return false when some features don't find matches", () => {
+      // First collection has two squares
+      const square1a = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      const square1b = [
+        [20, 0],
+        [20, 10],
+        [30, 10],
+        [30, 0],
+        [20, 0],
+      ];
+
+      // Second collection has one matching square and one non-matching
+      const square2a = [
+        [0.5, 0.5],
+        [0.5, 9.5],
+        [9.5, 9.5],
+        [9.5, 0.5],
+        [0.5, 0.5],
+      ]; // Matches square1a
+      const square2b = [
+        [40, 0],
+        [40, 10],
+        [50, 10],
+        [50, 0],
+        [40, 0],
+      ]; // Far from any square in fc1
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1a', square1a, props1), createPolygonFeature('f1b', square1b, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2a', square2a, props1), createPolygonFeature('f2b', square2b, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(false);
+    });
+
+    // Multiple features - different order
+    it('should match features correctly regardless of order', () => {
+      // First collection has two squares
+      const square1a = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+      const square1b = [
+        [20, 0],
+        [20, 10],
+        [30, 10],
+        [30, 0],
+        [20, 0],
+      ];
+
+      // Second collection has matching squares but in reverse order
+      const square2a = [
+        [0.5, 0.5],
+        [0.5, 9.5],
+        [9.5, 9.5],
+        [9.5, 0.5],
+        [0.5, 0.5],
+      ]; // Matches square1a
+      const square2b = [
+        [20.5, 0.5],
+        [20.5, 9.5],
+        [29.5, 9.5],
+        [29.5, 0.5],
+        [20.5, 0.5],
+      ]; // Matches square1b
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1a', square1a, props1), createPolygonFeature('f1b', square1b, props1)]);
+
+      const fc2 = createFeatureCollection([
+        // Order reversed compared to fc1
+        createPolygonFeature('f2b', square2b, props1),
+        createPolygonFeature('f2a', square2a, props1),
+      ]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(true);
+    });
+
+    // Ambiguous matching
+    it('should handle ambiguous matching correctly', () => {
+      // First collection has two identical squares at the same location
+      const square1 = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+
+      // Second collection has two identical squares at the same location
+      const square2 = [
+        [0.5, 0.5],
+        [0.5, 9.5],
+        [9.5, 9.5],
+        [9.5, 0.5],
+        [0.5, 0.5],
+      ];
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1a', square1, props1), createPolygonFeature('f1b', square1, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2a', square2, props1), createPolygonFeature('f2b', square2, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(true);
+    });
+
+    // Exactly at threshold boundary
+    it('should handle area ratio exactly at threshold boundary', () => {
+      // Square: 100 sq units
+      const outerSquare = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+
+      // Inner square with exactly 90% area of outer square - exactly at the threshold
+      // For a square, side length = sqrt(area)
+      // So sqrt(90) ≈ 9.487
+      const sideLength = Math.sqrt(90);
+      const offset = (10 - sideLength) / 2; // To center the smaller square
+
+      const innerSquare = [
+        [offset, offset],
+        [offset, offset + sideLength],
+        [offset + sideLength, offset + sideLength],
+        [offset + sideLength, offset],
+        [offset, offset],
+      ];
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1', outerSquare, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2', innerSquare, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+      expect(result).toBe(true);
+    });
+
+    // Invalid geometry handling
+    it('should handle invalid geometries gracefully', () => {
+      // Create valid geometry
+      const validSquare = [
+        [0, 0],
+        [0, 10],
+        [10, 10],
+        [10, 0],
+        [0, 0],
+      ];
+
+      // Create invalid geometry (self-intersecting polygon)
+      const invalidPolygon = [
+        [0, 0],
+        [10, 10],
+        [0, 10],
+        [10, 0],
+        [0, 0],
+      ];
+
+      const fc1 = createFeatureCollection([createPolygonFeature('f1', validSquare, props1)]);
+
+      const fc2 = createFeatureCollection([createPolygonFeature('f2', invalidPolygon, props1)]);
+
+      const result = checkRoiFeatureCollectionResemblance(fc1, fc2);
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/tests/unit/utils/geometry.spec.ts
+++ b/tests/unit/utils/geometry.spec.ts
@@ -1,7 +1,7 @@
 import { container } from 'tsyringe';
-import { Feature, Polygon } from 'geojson';
+import { Polygon } from 'geojson';
 import jsLogger from '@map-colonies/js-logger';
-import { RoiFeatureCollection, RoiProperties } from '@map-colonies/raster-shared';
+import { RoiFeatureCollection } from '@map-colonies/raster-shared';
 import * as turf from '@turf/turf';
 import { configMock, registerDefaultConfig } from '../../mocks/config';
 import { sanitizeBboxMock, sanitizeBboxRequestMock, notIntersectedPolygon } from '../../mocks/geometryMocks';

--- a/tests/unit/utils/geometry.spec.ts
+++ b/tests/unit/utils/geometry.spec.ts
@@ -477,7 +477,6 @@ describe('Geometry Utils', () => {
       };
 
       const fc1 = turf.featureCollection([turf.feature(square1Polygon, props1, { id: 'f1a' }), turf.feature(square1Polygon, props1, { id: 'f1b' })]);
-
       const fc2 = turf.featureCollection([turf.feature(square2Polygon, props1, { id: 'f2a' }), turf.feature(square2Polygon, props1, { id: 'f2b' })]);
 
       const result = checkRoiFeatureCollectionSimilarity(fc1, fc2, { config: configMock });


### PR DESCRIPTION
| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔  |
| New feature     | ✖  |
| Breaking change | ✖  |
| Deprecations    | ✖  |
| Documentation   | ✖  |
| Tests added     | ✖  |
| Chore           | ✖  |

Further information:
This PR adds smarter caching for exports by comparing map areas. Key improvements:

- Added checks to find similar (not just identical) map areas within configurable meters buffer
- Made sure both the shape and size of areas match closely enough
- Fixed comparison to work with multiple shapes in one request
- Added tests for all possible scenarios (exact matches, similar areas, different sizes)

Now the system can reuse existing exports when someone requests nearly the same area, saving processing time while ensuring accuracy.
